### PR TITLE
Adding Vagrant installation step and other change about installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,20 @@ For the setup to work properly you need to install:
 - **vagrant** from their official site [vagrant](https://www.vagrantup.com/downloads). The version you can install through your favourite package manager (apt, yum, ...) is probably not the latest one.
 - Install vagrant plugin vbguest: `vagrant plugin install vagrant-vbguest` (not needed anymore)
 
+```bash
+wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt update && sudo apt install vagrant=2.2.19
+```
+
 #### Ansible
 - *Create a python >= 3.8 virtualenv*
 
 ```bash
+sudo apt install git
+git clone git@github.com:Orange-Cyberdefense/GOAD.git
+cd GOAD/ansible
 sudo apt install python3.8-venv
-cd ansible
 python3.8 -m virtualenv .venv
 source .venv/bin/activate
 ```
@@ -78,8 +86,8 @@ To have the lab up and running this is the commands you should do:
 - VMs creation
 
 ```bash
-git clone git@github.com:Orange-Cyberdefense/GOAD.git
-cd GOAD/
+pwd
+/opt/GOAD
 vagrant up # this will create the vms
 ```
 

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ ansible-playbook -l dc2 domain_controller.yml
 
 #### Add some vulns
 ```
-ansible-playbook vulns.yml
+ansible-playbook vulnerabilities.yml
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Line 30-34 :

Add installation step for vagrant on Linux (Tested on Ubuntu 22.04), to avoid a WinRM Error from vagrant, see related issue : https://github.com/hashicorp/vagrant/issues/12807

Line 88-92 :

Move the git clone step to line 40-43, to better understand the "cd ansible" at the ansible installation step and change this with a "pwd" command.