### PR TITLE
Disable default vagrant synced folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,6 +38,8 @@ boxes = [
 #   { :name => "SRV03", :ip => "192.168.56.23", :box => "jborean93/WindowsServer2016", :os => "windows"}
 # ]
 
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+
   config.vm.provider "virtualbox" do |v|
     v.memory = 3000
     v.cpus = 2


### PR DESCRIPTION
Fixes #49.

I'm not sure if synced folders are required. Regardless, disabling the default shared folder seems like a good idea.

Note that this won't remove the shared folder from existing virtual machines which have already been provisioned - only newly provisioned virtual machines. Users will need to manually disable shared folders for previously provisioned virtual machines in VirtualBox.
