### PR TITLE
 LmCompatibilityLevel value correction

### DIFF
--- a/ansible/roles/vulns/ntlmdowngrade/tasks/main.yml
+++ b/ansible/roles/vulns/ntlmdowngrade/tasks/main.yml
@@ -1,7 +1,8 @@
 # values : https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/network-security-lan-manager-authentication-level
+# NTLMv1 downgrade attacks are possible with LmCompatibilityLevel 2 and below
 - name: Enable LmCompatibilityLevel
   win_regedit:
     path: HKLM:\System\CurrentControlSet\Control\Lsa
     name: LmCompatibilityLevel
-    data: 0x3
+    data: 0x2
     type: dword


### PR DESCRIPTION
Hi @Mayfly277, thanks for your work!
I am proposing this change because for what I tested and read on few blogs, NTLMv1 downgrade attacks cannot be made on MEEREEN if LmCompatibilityLevel is 3.  I tested both configurations and I was able to do NTLM downgrade on MEEREEN with LmCompatibilityLevel 2.

Cheers,

Diego