### PR TITLE
Refactor ansible inventory to allow for IP changes

### DIFF
--- a/ansible/ad-trusts.yml
+++ b/ansible/ad-trusts.yml
@@ -22,4 +22,4 @@
     remote_admin_password: "{{lab.domains[remote_forest].domain_password}}"
     zone_name: "{{remote_forest}}"
     remote_dc: "{{lab.domains[remote_forest].dc}}"
-    master_server: "{{groups[remote_dc][0]}}"
+    master_server: "{{hostvars[remote_dc].ansible_host}}"

--- a/ansible/data.yml
+++ b/ansible/data.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Read data files"
-  hosts: all
+  hosts: all:!elk
   connection: local
   vars_files:
     - "{{data_path}}/config.json"

--- a/ansible/host_vars/dc01.yml
+++ b/ansible/host_vars/dc01.yml
@@ -1,0 +1,3 @@
+dns_domain: dc01
+dict_key: dc01
+

--- a/ansible/host_vars/dc02.yml
+++ b/ansible/host_vars/dc02.yml
@@ -1,0 +1,3 @@
+dns_domain: dc01
+dict_key: dc02
+

--- a/ansible/host_vars/dc03.yml
+++ b/ansible/host_vars/dc03.yml
@@ -1,0 +1,3 @@
+dns_domain: dc03
+dict_key: dc03
+

--- a/ansible/host_vars/elk.yml
+++ b/ansible/host_vars/elk.yml
@@ -1,0 +1,6 @@
+ansible_connection: ssh
+ansible_ssh_user: vagrant
+ansible_ssh_private_key_file: ./.vagrant/machines/elk/virtualbox/private_key
+ansible_ssh_port: 22
+host_key_checking: false
+

--- a/ansible/host_vars/srv02.yml
+++ b/ansible/host_vars/srv02.yml
@@ -1,0 +1,3 @@
+dns_domain: dc02
+dict_key: srv02
+

--- a/ansible/host_vars/srv03.yml
+++ b/ansible/host_vars/srv03.yml
@@ -1,0 +1,3 @@
+dns_domain: dc03
+dict_key: srv03
+

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,3 +1,26 @@
+[default]
+; Note: ansible_host *MUST* be an IPv4 address or setting things like DNS
+; servers will break.
+; ------------------------------------------------
+; sevenkingdoms.local
+; ------------------------------------------------
+dc01 ansible_host=192.168.56.10
+; ------------------------------------------------
+; north.sevenkingdoms.local
+; ------------------------------------------------
+dc02 ansible_host=192.168.56.11
+srv02 ansible_host=192.168.56.22
+; ------------------------------------------------
+; essos.local
+; ------------------------------------------------
+dc03 ansible_host=192.168.56.12
+srv03 ansible_host=192.168.56.23
+; ------------------------------------------------
+; Other
+; ------------------------------------------------
+elk ansible_host=192.168.56.50
+
+
 [all:vars]
 ; domain_name : folder inside ad/
 domain_name=sevenkingdoms.local
@@ -14,50 +37,4 @@ ansible_winrm_read_timeout_sec=500
 enable_http_proxy=no
 ad_http_proxy=http://x.x.x.x:xxxx
 ad_https_proxy=http://x.x.x.x:xxxx
-
-; ------------------------------------------------
-; sevenkingdoms.local
-[dc01:vars]
-dns_domain=192.168.56.10
-dict_key=dc01
-[dc01]
-192.168.56.10
-
-; ------------------------------------------------
-; north.sevenkingdoms.local
-[dc02:vars]
-dns_domain=192.168.56.10
-dict_key=dc02
-[dc02]
-192.168.56.11
-
-[srv02:vars]
-dns_domain=192.168.56.11
-dict_key=srv02
-[srv02]
-192.168.56.22
-
-; ------------------------------------------------
-; essos.local
-[dc03:vars]
-dns_domain=192.168.56.12
-dict_key=dc03
-[dc03]
-192.168.56.12
-
-[srv03:vars]
-dns_domain=192.168.56.12
-dict_key=srv03
-[srv03]
-192.168.56.23
-
-; [elk:vars]
-; ansible_connection=ssh
-; ansible_ssh_user=vagrant
-; ansible_ssh_private_key_file=./.vagrant/machines/elk/virtualbox/private_key
-; ansible_ssh_port=22
-; host_key_checking = false
-; 
-; [elk]
-; 192.168.56.50
 

--- a/ansible/roles/child_domain/tasks/main.yml
+++ b/ansible/roles/child_domain/tasks/main.yml
@@ -2,7 +2,7 @@
   win_dns_client:
     adapter_names: "{{domain_adapter}}"
     ipv4_addresses:
-    - "{{dns_domain}}"
+    - "{{hostvars[dns_domain].ansible_host}}"
     log_path: C:\dns_log.txt
 
 # - name: "Add member server to {{parent_domain}}"

--- a/ansible/roles/domain_controller_slave/tasks/main.yml
+++ b/ansible/roles/domain_controller_slave/tasks/main.yml
@@ -2,7 +2,7 @@
   win_dns_client:
     adapter_names: "{{domain_adapter}}"
     ipv4_addresses:
-    - "{{dns_domain}}"
+    - "{{hostvars[dns_domain}.ansible_host}"
     log_path: C:\dns_log.txt
 
 - name: Promote the server to aditionnal DC

--- a/ansible/roles/logs_windows/tasks/winlogbeat.yml
+++ b/ansible/roles/logs_windows/tasks/winlogbeat.yml
@@ -48,8 +48,8 @@
   when: not winlogbeat_folder.stat.exists
 
 - name: Configure winlogbeat
-  win_copy:
-    src: winlogbeat.yml
+  win_template:
+    src: winlogbeat.yml.j2
     dest: "{{ winlogbeat_service.install_path_64 }}\\winlogbeat-{{ winlogbeat_service.version }}-windows-x86_64\\winlogbeat.yml"
   notify: restart-winlogbeat
 

--- a/ansible/roles/logs_windows/templates/winlogbeat.yml.j2
+++ b/ansible/roles/logs_windows/templates/winlogbeat.yml.j2
@@ -119,7 +119,7 @@ setup.template.settings:
 # Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
 # This requires a Kibana endpoint configuration.
 setup.kibana:
-  host: "192.168.56.50"
+  host: "{{ hostvars['elk'].ansible_host }}"
   # Kibana Host
   # Scheme and port can be left out and will be set to the default (http and 5601)
   # In case you specify and additional path, the scheme is required: http://localhost:5601/path
@@ -151,7 +151,7 @@ setup.kibana:
 # ---------------------------- Elasticsearch Output ----------------------------
 output.elasticsearch:
   # Array of hosts to connect to.
-  hosts: ["192.168.56.50:9200"]
+  hosts: ["{{ hostvars['elk'].ansible_host }}:9200"]
   username: "elastic"
   password: "changeme"
 

--- a/ansible/roles/member_server/tasks/main.yml
+++ b/ansible/roles/member_server/tasks/main.yml
@@ -2,7 +2,7 @@
   win_dns_client:
     adapter_names: "{{domain_adapter}}"
     ipv4_addresses:
-    - "{{dns_domain}}"
+    - "{{hostvars[dns_domain].ansible_host}}"
     log_path: C:\dns_log.txt
 
 - name: Verify File Server Role is installed.


### PR DESCRIPTION
My motivation for this change is to make it easy to use GOAD for setups with other IP spaces than the default.

- Move away from "one group per host" to host variables instead.
- This has a secondary effect of making the Ansible output easier to follow as it logs things like "dc01" instead of "192.168...".

E.g:
```
TASK [Gathering Facts]
ok: [dc03]
ok: [srv02]
ok: [srv03]
ok: [dc01]
ok: [dc02]
```

~~Marking as Draft untii my tests finish.~~ Seems to work with `main.yml` and `elk.yml`.

Adding a seasonal picture to make this PR a bit more festive.

![image](https://user-images.githubusercontent.com/149442/209391899-17f92b28-d03e-403e-8370-165df260c53d.png)
