### PR TITLE
Update README.md: Fix Ansible on Windows hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ host_key_checking = false
 
   3. install with docker
 ```bash
-sudo docker run -ti --rm --network host -h goadansible -v $(pwd):/goad -w /goad/ansible goadansible ansible-playbook elk.yml
+sudo docker run -ti --rm --network host -e ANSIBLE_CONFIG=/goad/ansible -h goadansible -v $(pwd):/goad -w /goad/ansible goadansible ansible-playbook elk.yml
 ```
 
   3. or install on hand : 


### PR DESCRIPTION
Without this variable set, newer Ansible versions fail on world-writable configuration files, as follows:

```
[WARNING]: Ansible is being run in a world writable directory (/goad/ansible), ignoring it as an ansible.cfg source. For more information
see https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
[WARNING]: Could not match supplied host pattern, ignoring: dc01
[WARNING]: Could not match supplied host pattern, ignoring: dc02
[WARNING]: Could not match supplied host pattern, ignoring: dc03
[WARNING]: Could not match supplied host pattern, ignoring: srv02
[WARNING]: Could not match supplied host pattern, ignoring: srv03

PLAY [build all] *************************************************************************************************************************
skipping: no hosts matched

PLAY [build all no update] ***************************************************************************************************************
skipping: no hosts matched
[...skipped additional skipped builds...]
```