### PR TITLE
[virtualbox] create boxes within a VBox group in the GUI

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,6 +74,7 @@ boxes = [
       # BOX
       target.vm.provider "virtualbox" do |v|
         v.name = box[:name]
+        v.customize ["modifyvm", :id, "--groups", "/GOAD"]
       end
       target.vm.box_download_insecure = box[:box]
       target.vm.box = box[:box]


### PR DESCRIPTION
Hi!

If you you have a lot of VM and like clean Vbox GUI like me, [you can tell](https://stackoverflow.com/a/51213380) Vagrant to create a Vbox group named "GOAD" and put VMs within it:

![Screenshot from 2023-05-21 12-28-28](https://github.com/Orange-Cyberdefense/GOAD/assets/18633286/8f508f23-a3fa-4f85-93ae-cf4c59a7a10a)

PS: It's the first time I use Vagrant, maybe not the cleaner way to do it

:sunflower: 
