### PR TITLE
Check for sudo before running

### DIFF
--- a/scripts/setup_proxmox.sh
+++ b/scripts/setup_proxmox.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if ! command -v sudo &> /dev/null
+then 
+  echo "sudo not installed, please install before running this script"
+  exit 1
+fi
+
 sudo apt update
 sudo apt install git vim tmux curl gnupg software-properties-common mkisofs
 


### PR DESCRIPTION
If the provisioner is a container it won't have sudo by default. This just adds some error checking.