### PR TITLE
Fix #168: Fix typo in install_with_virtualbox.md

### DIFF
--- a/docs/install_with_virtualbox.md
+++ b/docs/install_with_virtualbox.md
@@ -114,12 +114,12 @@ ansible-galaxy install -r ansible/requirements.yml
 - This will launch vagrant up and the ansible playbooks
 - If you run ansible locally
 ```bash
-./goad.sh -t check -l GOAD -p virtualbox -m local
+./goad.sh -t install -l GOAD -p virtualbox -m local
 ```
 
 - If you run ansible on docker
 ```bash
-./goad.sh -t check -l GOAD -p virtualbox -m local
+./goad.sh -t install -l GOAD -p virtualbox  -m docker
 ```
 
 ### Launch installation manually


### PR DESCRIPTION
- Automatic install instructions were checking instead of installing
- Fixed Ansible vs Docker commands being the same