### PR TITLE
Proxmox v8.x support

### DIFF
--- a/ad/GOAD/providers/proxmox/terraform/goad-v8.tf.template
+++ b/ad/GOAD/providers/proxmox/terraform/goad-v8.tf.template
@@ -3,7 +3,8 @@ resource "proxmox_vm_qemu" "dc01" {
     desc = "DC01 - windows server 2019 - 192.168.10.10"
     qemu_os = "win10"
     target_node = var.pm_node
-    pool = var.pm_pool
+    # pool not working, it error {\"pool\":\"property is not defined in schema and the schema does not allow additional properties\"}}
+    #pool = var.pm_pool
 
     sockets = 1
     cores = 2
@@ -11,29 +12,35 @@ resource "proxmox_vm_qemu" "dc01" {
     agent = 1
     clone = "WinServer2019x64-cloudinit-qcow2"
     full_clone = var.pm_full_clone
-    
-    disks {
-      ide{
-        ide0 {
+    os_type     = "cloud-init"
+    boot        = "order=sata0;ide3"
+    # disk type need to match with disk type in template, in this case sata0
+    bootdisk    = "sata0"
+    disks{
+      sata {
+        sata0 {
           disk {
-          size = 40
-          storage = "local-lvm"
+            size      = 40
+            storage   = "local-lvm"
           }
         }
       }
     }
-   network {
-     bridge    = "vmbr3"
-     model     = "e1000"
-     tag       = 10
-   }
-    #lifecycle {
-      #ignore_changes = [
-        #disk,
-      #]
-    #}
-   nameserver = "192.168.10.1"
-   ipconfig0 = "ip=192.168.10.10/24,gw=192.168.10.1"
+    # Specify the cloud-init cdrom storage
+    cloudinit_cdrom_storage = "local-lvm"
+
+    network {
+      bridge    = "vmbr3"
+      model     = "e1000"
+      tag       = 10
+    }
+      #lifecycle {
+        #ignore_changes = [
+          #disk,
+        #]
+      #}
+    nameserver = "192.168.10.1"
+    ipconfig0 = "ip=192.168.10.10/24,gw=192.168.10.1"
 }
 
 resource "proxmox_vm_qemu" "dc02" {
@@ -41,24 +48,31 @@ resource "proxmox_vm_qemu" "dc02" {
     desc = "DC02 - windows server 2019 - 192.168.10.11"
     qemu_os = "win10"
     target_node = var.pm_node
-    pool = var.pm_pool
+    # pool not working, it error {\"pool\":\"property is not defined in schema and the schema does not allow additional properties\"}}
+    #pool = var.pm_pool
     sockets = 1
     cores = 2
     memory = 3096
     agent = 1
     clone = "WinServer2019x64-cloudinit-qcow2"
     full_clone = var.pm_full_clone
-
-    disks {
-      ide{
-        ide0 {
+    os_type     = "cloud-init"
+    boot        = "order=sata0;ide3"
+    # disk type need to match with disk type in template, in this case sata0
+    bootdisk    = "sata0"
+    disks{
+      sata {
+        sata0 {
           disk {
-          size = 40
-          storage = "local-lvm"
+            size      = 40
+            storage   = "local-lvm"
           }
         }
       }
     }
+    # Specify the cloud-init cdrom storage
+    cloudinit_cdrom_storage = "local-lvm"
+
     network {
       bridge    = "vmbr3"
       model     = "e1000"
@@ -79,7 +93,8 @@ resource "proxmox_vm_qemu" "DC03" {
     qemu_os = "win10"
 
     target_node = var.pm_node
-    pool = var.pm_pool
+    # pool not working, it error {\"pool\":\"property is not defined in schema and the schema does not allow additional properties\"}}
+    #pool = var.pm_pool
 
     sockets = 1
     cores = 2
@@ -87,17 +102,23 @@ resource "proxmox_vm_qemu" "DC03" {
     agent = 1
     clone = "WinServer2016x64-cloudinit-qcow2"
     full_clone = var.pm_full_clone
-
-    disks {
-      ide{
-        ide0 {
+    os_type     = "cloud-init"
+    boot        = "order=sata0;ide3"
+    # disk type need to match with disk type in template, in this case sata0
+    bootdisk    = "sata0"
+    disks{
+      sata {
+        sata0 {
           disk {
-          size = 40
-          storage = "local-lvm"
+            size      = 40
+            storage   = "local-lvm"
           }
         }
       }
     }
+    # Specify the cloud-init cdrom storage
+    cloudinit_cdrom_storage = "local-lvm"
+
     network {
       bridge    = "vmbr3"
       model     = "e1000"
@@ -117,24 +138,31 @@ resource "proxmox_vm_qemu" "srv02" {
     desc = "SRV02 - windows server 2019 - 192.168.10.22"
     qemu_os = "win10"
     target_node = var.pm_node
-    pool = var.pm_pool
+    # pool not working, it error {\"pool\":\"property is not defined in schema and the schema does not allow additional properties\"}}
+    #pool = var.pm_pool
     sockets = 1
     cores = 2
     memory = 4096
     agent = 1
     clone = "WinServer2019x64-cloudinit-qcow2"
     full_clone = var.pm_full_clone
-
-    disks {
-      ide{
-        ide0 {
+    os_type     = "cloud-init"
+    boot        = "order=sata0;ide3"
+    # disk type need to match with disk type in template, in this case sata0
+    bootdisk    = "sata0"
+    disks{
+      sata {
+        sata0 {
           disk {
-          size = 40
-          storage = "local-lvm"
+            size      = 40
+            storage   = "local-lvm"
           }
         }
       }
     }
+    # Specify the cloud-init cdrom storage
+    cloudinit_cdrom_storage = "local-lvm"
+
     network {
       bridge    = "vmbr3"
       model     = "e1000"
@@ -154,24 +182,31 @@ resource "proxmox_vm_qemu" "srv03" {
     desc = "SRV03 - windows server 2016 - 192.168.10.23"
     qemu_os = "win10"
     target_node = var.pm_node
-    pool = var.pm_pool
+    # pool not working, it error {\"pool\":\"property is not defined in schema and the schema does not allow additional properties\"}}
+    #pool = var.pm_pool
     sockets = 1
     cores = 2
     memory = 4096
     agent = 1
     clone = "WinServer2016x64-cloudinit-qcow2"
     full_clone = var.pm_full_clone
-
-    disks {
-      ide{
-        ide0 {
+    os_type     = "cloud-init"
+    boot        = "order=sata0;ide3"
+    # disk type need to match with disk type in template, in this case sata0
+    bootdisk    = "sata0"
+    disks{
+      sata {
+        sata0 {
           disk {
-          size = 40
-          storage = "local-lvm"
+            size      = 40
+            storage   = "local-lvm"
           }
         }
       }
     }
+    # Specify the cloud-init cdrom storage
+    cloudinit_cdrom_storage = "local-lvm"
+
     network {
       bridge    = "vmbr3"
       model     = "e1000"

--- a/ad/GOAD/providers/proxmox/terraform/goad-v8.tf.template
+++ b/ad/GOAD/providers/proxmox/terraform/goad-v8.tf.template
@@ -1,0 +1,188 @@
+resource "proxmox_vm_qemu" "dc01" {
+    name = "GOAD-DC01"
+    desc = "DC01 - windows server 2019 - 192.168.10.10"
+    qemu_os = "win10"
+    target_node = var.pm_node
+    pool = var.pm_pool
+
+    sockets = 1
+    cores = 2
+    memory = 3096
+    agent = 1
+    clone = "WinServer2019x64-cloudinit-qcow2"
+    full_clone = var.pm_full_clone
+    
+    disks {
+      ide{
+        ide0 {
+          disk {
+          size = 40
+          storage = "local-lvm"
+          }
+        }
+      }
+    }
+   network {
+     bridge    = "vmbr3"
+     model     = "e1000"
+     tag       = 10
+   }
+    #lifecycle {
+      #ignore_changes = [
+        #disk,
+      #]
+    #}
+   nameserver = "192.168.10.1"
+   ipconfig0 = "ip=192.168.10.10/24,gw=192.168.10.1"
+}
+
+resource "proxmox_vm_qemu" "dc02" {
+    name = "GOAD-DC02"
+    desc = "DC02 - windows server 2019 - 192.168.10.11"
+    qemu_os = "win10"
+    target_node = var.pm_node
+    pool = var.pm_pool
+    sockets = 1
+    cores = 2
+    memory = 3096
+    agent = 1
+    clone = "WinServer2019x64-cloudinit-qcow2"
+    full_clone = var.pm_full_clone
+
+    disks {
+      ide{
+        ide0 {
+          disk {
+          size = 40
+          storage = "local-lvm"
+          }
+        }
+      }
+    }
+    network {
+      bridge    = "vmbr3"
+      model     = "e1000"
+      tag       = 10
+    }
+    #lifecycle {
+      #ignore_changes = [
+        #disk,
+      #]
+    #}
+   nameserver = "192.168.10.1"
+   ipconfig0 = "ip=192.168.10.11/24,gw=192.168.10.1"
+}
+
+resource "proxmox_vm_qemu" "DC03" {
+    name = "GOAD-DC03"
+    desc = "DC03 - windows server 2016 - 192.168.10.12"
+    qemu_os = "win10"
+
+    target_node = var.pm_node
+    pool = var.pm_pool
+
+    sockets = 1
+    cores = 2
+    memory = 3096
+    agent = 1
+    clone = "WinServer2016x64-cloudinit-qcow2"
+    full_clone = var.pm_full_clone
+
+    disks {
+      ide{
+        ide0 {
+          disk {
+          size = 40
+          storage = "local-lvm"
+          }
+        }
+      }
+    }
+    network {
+      bridge    = "vmbr3"
+      model     = "e1000"
+      tag       = 10
+    }
+    #lifecycle {
+      #ignore_changes = [
+        #disk,
+      #]
+    #}
+   nameserver = "192.168.10.1"
+   ipconfig0 = "ip=192.168.10.12/24,gw=192.168.10.1"
+}
+
+resource "proxmox_vm_qemu" "srv02" {
+    name = "GOAD-SRV02"
+    desc = "SRV02 - windows server 2019 - 192.168.10.22"
+    qemu_os = "win10"
+    target_node = var.pm_node
+    pool = var.pm_pool
+    sockets = 1
+    cores = 2
+    memory = 4096
+    agent = 1
+    clone = "WinServer2019x64-cloudinit-qcow2"
+    full_clone = var.pm_full_clone
+
+    disks {
+      ide{
+        ide0 {
+          disk {
+          size = 40
+          storage = "local-lvm"
+          }
+        }
+      }
+    }
+    network {
+      bridge    = "vmbr3"
+      model     = "e1000"
+      tag       = 10
+    }
+    #lifecycle {
+      #ignore_changes = [
+        #disk,
+      #]
+    #}
+    nameserver = "192.168.10.1"
+    ipconfig0 = "ip=192.168.10.22/24,gw=192.168.10.1"
+}
+
+resource "proxmox_vm_qemu" "srv03" {
+    name = "GOAD-SRV03"
+    desc = "SRV03 - windows server 2016 - 192.168.10.23"
+    qemu_os = "win10"
+    target_node = var.pm_node
+    pool = var.pm_pool
+    sockets = 1
+    cores = 2
+    memory = 4096
+    agent = 1
+    clone = "WinServer2016x64-cloudinit-qcow2"
+    full_clone = var.pm_full_clone
+
+    disks {
+      ide{
+        ide0 {
+          disk {
+          size = 40
+          storage = "local-lvm"
+          }
+        }
+      }
+    }
+    network {
+      bridge    = "vmbr3"
+      model     = "e1000"
+      tag       = 10
+    }
+
+    #lifecycle {
+      #ignore_changes = [
+        #disk,
+      #]
+    #}
+    nameserver = "192.168.10.1"
+    ipconfig0 = "ip=192.168.10.23/24,gw=192.168.10.1"
+}

--- a/ad/GOAD/providers/proxmox/terraform/main.tf
+++ b/ad/GOAD/providers/proxmox/terraform/main.tf
@@ -1,8 +1,12 @@
 terraform {
   required_providers {
+    #proxmox = {
+      #source = "telmate/proxmox"
+      #version = ">=1.0.0"
+    #}
     proxmox = {
-      source = "telmate/proxmox"
-      version = ">=1.0.0"
+      source  = "thegameprofi/proxmox"
+      version = ">= 2.9.15"
     }
   }
 }

--- a/ad/GOAD/providers/proxmox/terraform/main.tf
+++ b/ad/GOAD/providers/proxmox/terraform/main.tf
@@ -1,12 +1,8 @@
 terraform {
   required_providers {
-    #proxmox = {
-      #source = "telmate/proxmox"
-      #version = ">=1.0.0"
-    #}
     proxmox = {
-      source  = "thegameprofi/proxmox"
-      version = ">= 2.9.15"
+      source = "Telmate/proxmox"
+      version = "3.0.1-rc1"
     }
   }
 }


### PR DESCRIPTION
When using the Telmate/Proxmox v2.9.14, it will not working for proxmox v8.x and showing error like this

```
╷
│ Error: Plugin did not respond
│
│   with proxmox_vm_qemu.srv02,
│   on goad.tf line 85, in resource "proxmox_vm_qemu" "srv02":
│   85: resource "proxmox_vm_qemu" "srv02" {
│
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵
╷
│ Error: Plugin did not respond
│
│   with proxmox_vm_qemu.srv03,
│   on goad.tf line 112, in resource "proxmox_vm_qemu" "srv03":
│  112: resource "proxmox_vm_qemu" "srv03" {
│
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-proxmox_v2.9.14 plugin:

panic: interface conversion: interface {} is string, not float64

goroutine 68 [running]:
github.com/Telmate/proxmox-api-go/proxmox.NewConfigQemuFromApi(0xc0005a4718, 0xc9d509?)
	github.com/Telmate/proxmox-api-go@v0.0.0-20230319185744-e7cde7198cdf/proxmox/config_qemu.go:584 +0x4605
github.com/Telmate/terraform-provider-proxmox/proxmox.resourceVmQemuCreate(0xc0000dcf80, {0xb66f60?, 0xc000478000})
	github.com/Telmate/terraform-provider-proxmox/proxmox/resource_vm_qemu.go:972 +0x2c4d
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xdd7840?, {0xdd7840?, 0xc0006173b0?}, 0xd?, {0xb66f60?, 0xc000478000?})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.25.0/helper/schema/resource.go:695 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0002ca7e0, {0xdd7840, 0xc0006173b0}, 0xc000453040, 0xc0000dce00, {0xb66f60, 0xc000478000})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.25.0/helper/schema/resource.go:837 +0xa85
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000354b70, {0xdd7840?, 0xc000617290?}, 0xc00022e550)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.25.0/helper/schema/grpc_provider.go:1021 +0xe8d
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc0002303c0, {0xdd7840?, 0xc000616a80?}, 0xc00027e070)
	github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/tf5server/server.go:818 +0x574
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0xc6bc20?, 0xc0002303c0}, {0xdd7840, 0xc000616a80}, 0xc00027e000, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000370000, {0xddb420, 0xc0000e8ea0}, 0xc000545440, 0xc00036ed20, 0x128f7a0, 0x0)
	google.golang.org/grpc@v1.53.0/server.go:1336 +0xd23
google.golang.org/grpc.(*Server).handleStream(0xc000370000, {0xddb420, 0xc0000e8ea0}, 0xc000545440, 0x0)
	google.golang.org/grpc@v1.53.0/server.go:1704 +0xa2f
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	google.golang.org/grpc@v1.53.0/server.go:965 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.53.0/server.go:963 +0x28a

Error: The terraform-provider-proxmox_v2.9.14 plugin crashed!
```

Here is the discussion about this issue https://github.com/Telmate/terraform-provider-proxmox/issues/863 . As far as I understand, the Telmate repo already patched it but in rc1 release tag. So I've updated the script to use 

```
    proxmox = {
      source = "Telmate/proxmox"
      version = "3.0.1-rc1"
    }
```

After changing the script, it work

```
# terraform apply "goad.plan"
proxmox_vm_qemu.DC03: Destroying... 
proxmox_vm_qemu.srv02: Destroying... 
proxmox_vm_qemu.dc02: Destroying...
proxmox_vm_qemu.srv03: Creating...
proxmox_vm_qemu.dc01: Creating...
proxmox_vm_qemu.DC03: Destruction complete after 2s
proxmox_vm_qemu.dc02: Destruction complete after 2s
proxmox_vm_qemu.srv02: Destruction complete after 2s
proxmox_vm_qemu.DC03: Creating...
proxmox_vm_qemu.dc02: Creating...
proxmox_vm_qemu.srv02: Creating...
proxmox_vm_qemu.dc01: Still creating... [10s elapsed]
proxmox_vm_qemu.dc02: Still creating... [10s elapsed]
proxmox_vm_qemu.srv02: Still creating... [10s elapsed]
proxmox_vm_qemu.dc02: Still creating... [20s elapsed]
proxmox_vm_qemu.srv02: Still creating... [20s elapsed]
proxmox_vm_qemu.dc02: Still creating... [30s elapsed]
proxmox_vm_qemu.srv02: Still creating... [30s elapsed]
```