### PR TITLE
Add ESXi support to GOAD scenario using esxi Vagrant plugin

### DIFF
--- a/ad/GOAD/providers/esxi/Vagrantfile
+++ b/ad/GOAD/providers/esxi/Vagrantfile
@@ -1,0 +1,76 @@
+Vagrant.configure("2") do |config|
+boxes = [
+  # windows server 2019
+  { :name => "GOAD-DC01",  :ip => "192.168.56.10", :box => "StefanScherer/windows_2019", :box_version => "2021.05.15", :os => "windows"},
+  # windows server 2019
+  { :name => "GOAD-DC02",  :ip => "192.168.56.11", :box => "StefanScherer/windows_2019", :box_version => "2021.05.15", :os => "windows"},
+  # windows server 2016
+  { :name => "GOAD-DC03",  :ip => "192.168.56.12", :box => "StefanScherer/windows_2016", :box_version => "2017.12.14", :os => "windows"},
+  # windows server 2019
+  { :name => "GOAD-SRV02", :ip => "192.168.56.22", :box => "StefanScherer/windows_2019", :box_version => "2020.07.17", :os => "windows"},
+  # windows server 2016
+  { :name => "GOAD-SRV03", :ip => "192.168.56.23", :box => "StefanScherer/windows_2016", :box_version => "2019.02.14", :os => "windows"}
+]
+
+
+  # disable rdp forwarded port inherited from StefanScherer box
+  config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true, disabled: true
+
+  # no autoupdate if vagrant-vbguest is installed
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
+  config.vm.boot_timeout = 600
+  config.vm.graceful_halt_timeout = 600
+  config.winrm.retry_limit = 30
+  config.winrm.retry_delay = 10
+
+  boxes.each do |box|
+    config.vm.define box[:name] do |target|
+      # BOX
+      target.vm.box_download_insecure = box[:box]
+      target.vm.box = box[:box]
+      if box.has_key?(:box_version)
+        target.vm.box_version = box[:box_version]
+      end
+
+      # issues/49
+      target.vm.synced_folder '.', '/vagrant', disabled: true
+
+      # IP
+      target.vm.network :private_network, ip: box[:ip]
+
+      # OS specific
+      if box[:os] == "windows"
+        target.vm.hostname = box[:name]
+        target.vm.guest = :windows
+        target.vm.communicator = "winrm"
+        target.vm.provision :shell, :path => "../../../../vagrant/Install-WMF3Hotfix.ps1", privileged: false
+        target.vm.provision :shell, :path => "../../../../vagrant/ConfigureRemotingForAnsible.ps1", privileged: false
+        target.vm.provision :shell, :path => "../../../../vagrant/fix_ip.ps1", privileged: false, args: box[:ip]
+      else
+        target.vm.communicator = "ssh"
+      end
+
+      if box.has_key?(:forwarded_port)
+        # forwarded port explicit
+        box[:forwarded_port] do |forwarded_port|
+          target.vm.network :forwarded_port, guest: forwarded_port[:guest], host: forwarded_port[:host], host_ip: "127.0.0.1", id: forwarded_port[:id]
+        end
+      end
+      config.vm.provider :vmware_esxi do |esxi|
+        esxi.esxi_hostname         = '10.10.10.10'
+        esxi.esxi_username         = 'USERNAME'
+        esxi.esxi_password         = 'PASSWORD'
+        esxi.esxi_virtual_network  = ["LAN Mgt 10.10.10", "LAN LAB"]
+        esxi.guest_numvcpus        = 2
+        esxi.guest_memsize         = 4000
+        #esxi.clone_from_vm        = box
+        esxi.local_allow_overwrite = 'True'
+        esxi.esxi_disk_store = 'ESXI-DATASTORE'
+        esxi.debug = 'True'
+      end
+    end
+  end
+end

--- a/ad/GOAD/providers/esxi/inventory
+++ b/ad/GOAD/providers/esxi/inventory
@@ -1,0 +1,57 @@
+[default]
+; Note: ansible_host *MUST* be an IPv4 address or setting things like DNS
+; servers will break.
+; ------------------------------------------------
+; sevenkingdoms.local
+; ------------------------------------------------
+dc01 ansible_host=192.168.56.10 dns_domain=dc01 dict_key=dc01
+;ws01 ansible_host=192.168.56.30 dns_domain=dc01 dict_key=ws01
+; ------------------------------------------------
+; north.sevenkingdoms.local
+; ------------------------------------------------
+dc02 ansible_host=192.168.56.11 dns_domain=dc01 dict_key=dc02
+srv02 ansible_host=192.168.56.22 dns_domain=dc02 dict_key=srv02
+; ------------------------------------------------
+; essos.local
+; ------------------------------------------------
+dc03 ansible_host=192.168.56.12 dns_domain=dc03 dict_key=dc03
+srv03 ansible_host=192.168.56.23 dns_domain=dc03 dict_key=srv03
+; ------------------------------------------------
+; Other
+; ------------------------------------------------
+elk ansible_host=192.168.56.50 ansible_connection=ssh
+
+[all:vars]
+; domain_name : folder inside ad/
+domain_name=GOAD
+
+force_dns_server=no
+dns_server=x.x.x.x
+two_adapters=yes
+
+; adapter created by vagrant and vmware (uncomment if you use vmware)
+nat_adapter=Ethernet0
+domain_adapter=Ethernet1
+
+; winrm connection (windows)
+ansible_user=vagrant
+ansible_password=vagrant
+ansible_connection=winrm
+ansible_winrm_server_cert_validation=ignore
+ansible_winrm_operation_timeout_sec=400
+ansible_winrm_read_timeout_sec=500
+# ansible_winrm_transport=basic
+# ansible_port=5985
+
+; proxy settings (the lab need internet for some install, if you are behind a proxy you should set the proxy here)
+enable_http_proxy=no
+ad_http_proxy=http://x.x.x.x:xxxx
+ad_https_proxy=http://x.x.x.x:xxxx
+
+[elk_server:vars]
+; ssh connection (linux)
+ansible_ssh_user=vagrant
+ansible_ssh_private_key_file=./.vagrant/machines/elk/virtualbox/private_key
+ansible_ssh_port=22
+ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+


### PR DESCRIPTION
First of all : Many thanks to this AWESOME repo.

This Vagrantfile is giving a way to integrate with ESXi using Vagrant Plugin from : https://github.com/josenk/vagrant-vmware-esxi
I know that is a dead architecture, but I have one up and running and it helps me a lot to use it. So I thought it should help others.
There is no modification in the `inventory` file. Just copied in folder for consistency

These lines need to be customised to match your lab environment: 

```
esxi.esxi_hostname         = '10.10.10.10'
esxi.esxi_username         = 'USERNAME'
esxi.esxi_password         = 'PASSWORD'
esxi.esxi_virtual_network  = ["LAN Mgt 10.10.10", "LAN LAB"]
esxi.esxi_disk_store.      = 'ESXI-DATASTORE'
```

It must be launch from repository `ad/GOAD/providers/esxi/` using `vagrant up` 

TODO:

- Better manage user environment variables
- Add esxi provider in goad.sh script
- Anything you want :)

I hope it should help and thanks again
