### PR TITLE
Ensure windows update services are running before IIS install

### DIFF
--- a/ansible/roles/iis/tasks/main.yml
+++ b/ansible/roles/iis/tasks/main.yml
@@ -1,3 +1,9 @@
+- name: Enable update service
+  ansible.windows.win_service:
+    name: Windows Update
+    state: started
+    start_mode: auto
+
 - name: Install IIS Management Features
   win_feature:
     name: Web-Mgmt-Tools, 


### PR DESCRIPTION
This change ensures that the windows update service is started before attempting to install IIS. On hosts where the windows update service is stopped (i.e. Ludus hosts) this causes the IIS install to complete when it would otherwise fail.