### PR TITLE
Enable windows updates before IIS install

### DIFF
--- a/ansible/roles/sccm/install/iis/tasks/main.yml
+++ b/ansible/roles/sccm/install/iis/tasks/main.yml
@@ -22,6 +22,12 @@
   ansible.windows.win_reboot:
   when: win_feature.reboot_required
 
+- name: Enable update service
+  ansible.windows.win_service:
+    name: Windows Update
+    state: started
+    start_mode: auto
+
 - name: install .NET Framework 3.5 with DISM
   win_shell: DISM /Online /Enable-Feature /FeatureName:NetFx3 /All
   vars:


### PR DESCRIPTION
Enable windows updates before IIS install for the SCCM lab. This fixes issues with hosts that do not have the windows update service running (ludus hosts).

Fixes #205 