### PR TITLE
Ludus range inventory disable

### DIFF
--- a/ansible/disable_localuser.yml
+++ b/ansible/disable_localuser.yml
@@ -1,0 +1,16 @@
+---
+# Load datas
+- import_playbook: data.yml
+  vars:
+    data_path: "../ad/{{domain_name}}/data/"
+  tags: 'data'
+
+- name: "Disable localuser for Ludus Range"
+  hosts: domain
+  roles:
+    - { role: 'disable_localuser_ludus'}
+  vars:
+    domain: "{{lab.hosts[dict_key].domain}}"
+    member_domain: "{{lab.hosts[dict_key].domain}}"
+    domain_username: "{{domain}}\\Administrator"
+    domain_password: "{{lab.domains[member_domain].domain_password}}"

--- a/ansible/roles/disable_localuser_ludus/main.yml
+++ b/ansible/roles/disable_localuser_ludus/main.yml
@@ -1,0 +1,9 @@
+- name: Disable the user 'localuser'
+  ansible.windows.win_user:
+    name: localuser
+    account_disabled: true
+  become: yes
+  become_method: runas
+  become_user: "{{domain_username}}"
+  vars:
+    ansible_become_pass: "{{domain_password}}"


### PR DESCRIPTION
This is to disable the localuser account for Ludus once the range is setup, this is useful for users deploying the NHA lab and to prevent an easy way to the box