### PR TITLE
Fix NHA Academy website

### DIFF
--- a/ad/NHA/files/wwwroot/Web.config
+++ b/ad/NHA/files/wwwroot/Web.config
@@ -15,8 +15,8 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <system.web>
-    <compilation targetFramework="4.7.2" />
-    <httpRuntime targetFramework="4.7.2" />
+    <compilation targetFramework="4.0.0" />
+    <httpRuntime targetFramework="4.0.0" />
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
Fix .net version for academy website runtime

The server does not come with .net 4.7.2. which will break the website 
In order to make it work, it was necessary to downgrade the runtime version in this config.