### PR TITLE
Update provisionning.sh to prevent error message when ANSIBLE_COMMAND is defined

### DIFF
--- a/scripts/provisionning.sh
+++ b/scripts/provisionning.sh
@@ -11,7 +11,7 @@ MAX_RETRY=3
 echo "[+] Current folder $(pwd)"
 echo "[+] Current LAB : $LAB"
 echo "[+] Current PROVIDER : $PROVIDER"
-if [ -z  $ANSIBLE_COMMAND ]; then
+if [ -z  "$ANSIBLE_COMMAND" ]; then
   export ANSIBLE_COMMAND="ansible-playbook -i ../ad/$LAB/data/inventory -i ../ad/$LAB/providers/$PROVIDER/inventory"
 fi
 echo "[+] Ansible command : $ANSIBLE_COMMAND"


### PR DESCRIPTION
Ludus users see

```
/scripts/provisionning.sh: line 14: [: syntax error: -i' unexpected
```

because ANSIBLE_COMMAND is defined and thus the check expands the var into

```
if [ -z ansible-playbook -i ../ad/GOAD/data/inventory -i ./inventory.yml ]; then
```

without the quotes which sends the `-i` as an arg to the `[` command. Adding quotes around the variable fixes this issue.