### PR TITLE
Added ansible role to add local users to systems

### DIFF
--- a/ansible/localusers.yml
+++ b/ansible/localusers.yml
@@ -1,0 +1,14 @@
+---
+# Load datas
+- import_playbook: data.yml
+  vars:
+    data_path: "../ad/{{domain_name}}/data/"
+  tags: 'data'
+
+# set local users ==================================================================================================
+- name: Local Users
+  hosts: domain
+  roles:
+    - { role: 'localusers', tags: 'localusers' }
+  vars:
+    local_users: "{{ lab.hosts[dict_key].local_users | default({}) }}"

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -31,6 +31,7 @@
 - import_playbook: ad-gmsa.yml
 # install LAPS
 - import_playbook: laps.yml
+- import_playbook: localusers.yml
 ## MSSQL + IIS  ----------
 # configure servers vulns (done in the middle of ad install to let time before install relations and acl)
 #- import_playbook: servers.yml

--- a/ansible/roles/localusers/tasks/main.yml
+++ b/ansible/roles/localusers/tasks/main.yml
@@ -1,0 +1,10 @@
+- name: "Create local users"
+  ansible.windows.win_user:
+    name: "{{ item.key }}"
+    password: "{{ item.value.password }}"
+    state: present
+    groups: "{{ item.value.groups }}"
+    password_never_expires: true
+    user_cannot_change_password: true
+    account_disabled: "{{ item.value.disabled | default(false) }}"
+  with_dict: "{{ local_users }}"


### PR DESCRIPTION
I recently needed the ability to add local users, so I thought maybe others could use this too.

This PR adds a ansible role to add local users to systems.

You can use it by adding a section to a system in the `config.json` file. In this example the user `alice` is added to the local administrators group of host `ws01`:
~~~json
....
"ws01" : {
    ...
    "local_users" : {
        "alice" : {
            "password": "SecurePassw0rd",
            "disabled": false,
            "groups": [
                "Administrators"
            ]
        }
    }
    ...
}
~~~

I didn't know if I should update the goad.sh script as well to allow running this role alone.