### PR TITLE
Replace dict_key by inventory_hostname

### DIFF
--- a/ad/GOAD-Light/providers/azure/inventory
+++ b/ad/GOAD-Light/providers/azure/inventory
@@ -4,12 +4,12 @@
 ; ------------------------------------------------
 ; sevenkingdoms.local
 ; ------------------------------------------------
-dc01 ansible_host=192.168.56.10 dns_domain=dc01 dict_key=dc01 ansible_user=ansible ansible_password=8dCT-DJjgScp
+dc01 ansible_host=192.168.56.10 dns_domain=dc01 ansible_user=ansible ansible_password=8dCT-DJjgScp
 ; ------------------------------------------------
 ; north.sevenkingdoms.local
 ; ------------------------------------------------
-dc02 ansible_host=192.168.56.11 dns_domain=dc01 dict_key=dc02 ansible_user=ansible ansible_password=NgtI75cKV+Pu
-srv02 ansible_host=192.168.56.22 dns_domain=dc02 dict_key=srv02 ansible_user=ansible ansible_password=NgtI75cKV+Pu
+dc02 ansible_host=192.168.56.11 dns_domain=dc01 ansible_user=ansible ansible_password=NgtI75cKV+Pu
+srv02 ansible_host=192.168.56.22 dns_domain=dc02 ansible_user=ansible ansible_password=NgtI75cKV+Pu
 ; ------------------------------------------------
 ; Other
 ; ------------------------------------------------

--- a/ad/GOAD-Light/providers/proxmox/inventory
+++ b/ad/GOAD-Light/providers/proxmox/inventory
@@ -2,13 +2,13 @@
 ; ------------------------------------------------
 ; sevenkingdoms.local
 ; ------------------------------------------------
-dc01 ansible_host=192.168.10.10 dns_domain=dc01 dict_key=dc01
-;ws01 ansible_host=192.168.10.30 dns_domain=dc01 dict_key=ws01
+dc01 ansible_host=192.168.10.10 dns_domain=dc01
+;ws01 ansible_host=192.168.10.30 dns_domain=dc01
 ; ------------------------------------------------
 ; north.sevenkingdoms.local
 ; ------------------------------------------------
-dc02 ansible_host=192.168.10.11 dns_domain=dc01 dict_key=dc02
-srv02 ansible_host=192.168.10.22 dns_domain=dc02 dict_key=srv02
+dc02 ansible_host=192.168.10.11 dns_domain=dc01
+srv02 ansible_host=192.168.10.22 dns_domain=dc02
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/GOAD-Light/providers/virtualbox/inventory
+++ b/ad/GOAD-Light/providers/virtualbox/inventory
@@ -4,12 +4,12 @@
 ; ------------------------------------------------
 ; sevenkingdoms.local
 ; ------------------------------------------------
-dc01 ansible_host=192.168.56.10 dns_domain=dc01 dict_key=dc01
+dc01 ansible_host=192.168.56.10 dns_domain=dc01
 ; ------------------------------------------------
 ; north.sevenkingdoms.local
 ; ------------------------------------------------
-dc02 ansible_host=192.168.56.11 dns_domain=dc01 dict_key=dc02
-srv02 ansible_host=192.168.56.22 dns_domain=dc02 dict_key=srv02
+dc02 ansible_host=192.168.56.11 dns_domain=dc01
+srv02 ansible_host=192.168.56.22 dns_domain=dc02
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/GOAD-Light/providers/vmware/inventory
+++ b/ad/GOAD-Light/providers/vmware/inventory
@@ -4,12 +4,12 @@
 ; ------------------------------------------------
 ; sevenkingdoms.local
 ; ------------------------------------------------
-dc01 ansible_host=192.168.56.10 dns_domain=dc01 dict_key=dc01
+dc01 ansible_host=192.168.56.10 dns_domain=dc01
 ; ------------------------------------------------
 ; north.sevenkingdoms.local
 ; ------------------------------------------------
-dc02 ansible_host=192.168.56.11 dns_domain=dc01 dict_key=dc02
-srv02 ansible_host=192.168.56.22 dns_domain=dc02 dict_key=srv02
+dc02 ansible_host=192.168.56.11 dns_domain=dc01
+srv02 ansible_host=192.168.56.22 dns_domain=dc02
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/GOAD/providers/azure/inventory
+++ b/ad/GOAD/providers/azure/inventory
@@ -4,17 +4,17 @@
 ; ------------------------------------------------
 ; sevenkingdoms.local
 ; ------------------------------------------------
-dc01 ansible_host=192.168.56.10 dns_domain=dc01 dict_key=dc01 ansible_user=ansible ansible_password=8dCT-DJjgScp
+dc01 ansible_host=192.168.56.10 dns_domain=dc01 ansible_user=ansible ansible_password=8dCT-DJjgScp
 ; ------------------------------------------------
 ; north.sevenkingdoms.local
 ; ------------------------------------------------
-dc02 ansible_host=192.168.56.11 dns_domain=dc01 dict_key=dc02 ansible_user=ansible ansible_password=NgtI75cKV+Pu
-srv02 ansible_host=192.168.56.22 dns_domain=dc02 dict_key=srv02 ansible_user=ansible ansible_password=NgtI75cKV+Pu
+dc02 ansible_host=192.168.56.11 dns_domain=dc01 ansible_user=ansible ansible_password=NgtI75cKV+Pu
+srv02 ansible_host=192.168.56.22 dns_domain=dc02 ansible_user=ansible ansible_password=NgtI75cKV+Pu
 ; ------------------------------------------------
 ; essos.local
 ; ------------------------------------------------
-dc03 ansible_host=192.168.56.12 dns_domain=dc03 dict_key=dc03 ansible_user=ansible ansible_password=Ufe-bVXSx9rk
-srv03 ansible_host=192.168.56.23 dns_domain=dc03 dict_key=srv03 ansible_user=ansible ansible_password=978i2pF43UJ-
+dc03 ansible_host=192.168.56.12 dns_domain=dc03 ansible_user=ansible ansible_password=Ufe-bVXSx9rk
+srv03 ansible_host=192.168.56.23 dns_domain=dc03 ansible_user=ansible ansible_password=978i2pF43UJ-
 ; ------------------------------------------------
 ; Other
 ; ------------------------------------------------

--- a/ad/GOAD/providers/proxmox/inventory
+++ b/ad/GOAD/providers/proxmox/inventory
@@ -4,18 +4,18 @@
 ; ------------------------------------------------
 ; sevenkingdoms.local
 ; ------------------------------------------------
-dc01 ansible_host=192.168.10.10 dns_domain=dc01 dict_key=dc01
-;ws01 ansible_host=192.168.10.30 dns_domain=dc01 dict_key=ws01
+dc01 ansible_host=192.168.10.10 dns_domain=dc01
+;ws01 ansible_host=192.168.10.30 dns_domain=dc01
 ; ------------------------------------------------
 ; north.sevenkingdoms.local
 ; ------------------------------------------------
-dc02 ansible_host=192.168.10.11 dns_domain=dc01 dict_key=dc02
-srv02 ansible_host=192.168.10.22 dns_domain=dc02 dict_key=srv02
+dc02 ansible_host=192.168.10.11 dns_domain=dc01
+srv02 ansible_host=192.168.10.22 dns_domain=dc02
 ; ------------------------------------------------
 ; essos.local
 ; ------------------------------------------------
-dc03 ansible_host=192.168.10.12 dns_domain=dc03 dict_key=dc03
-srv03 ansible_host=192.168.10.23 dns_domain=dc03 dict_key=srv03
+dc03 ansible_host=192.168.10.12 dns_domain=dc03
+srv03 ansible_host=192.168.10.23 dns_domain=dc03
 ; ------------------------------------------------
 ; Other
 ; ------------------------------------------------

--- a/ad/GOAD/providers/virtualbox/inventory
+++ b/ad/GOAD/providers/virtualbox/inventory
@@ -4,18 +4,18 @@
 ; ------------------------------------------------
 ; sevenkingdoms.local
 ; ------------------------------------------------
-dc01 ansible_host=192.168.56.10 dns_domain=dc01 dict_key=dc01
-;ws01 ansible_host=192.168.56.30 dns_domain=dc01 dict_key=ws01
+dc01 ansible_host=192.168.56.10 dns_domain=dc01
+;ws01 ansible_host=192.168.56.30 dns_domain=dc01
 ; ------------------------------------------------
 ; north.sevenkingdoms.local
 ; ------------------------------------------------
-dc02 ansible_host=192.168.56.11 dns_domain=dc01 dict_key=dc02
-srv02 ansible_host=192.168.56.22 dns_domain=dc02 dict_key=srv02
+dc02 ansible_host=192.168.56.11 dns_domain=dc01
+srv02 ansible_host=192.168.56.22 dns_domain=dc02
 ; ------------------------------------------------
 ; essos.local
 ; ------------------------------------------------
-dc03 ansible_host=192.168.56.12 dns_domain=dc03 dict_key=dc03
-srv03 ansible_host=192.168.56.23 dns_domain=dc03 dict_key=srv03
+dc03 ansible_host=192.168.56.12 dns_domain=dc03
+srv03 ansible_host=192.168.56.23 dns_domain=dc03
 ; ------------------------------------------------
 ; Other
 ; ------------------------------------------------

--- a/ad/GOAD/providers/vmware/inventory
+++ b/ad/GOAD/providers/vmware/inventory
@@ -4,18 +4,18 @@
 ; ------------------------------------------------
 ; sevenkingdoms.local
 ; ------------------------------------------------
-dc01 ansible_host=192.168.56.10 dns_domain=dc01 dict_key=dc01
-;ws01 ansible_host=192.168.56.30 dns_domain=dc01 dict_key=ws01
+dc01 ansible_host=192.168.56.10 dns_domain=dc01
+;ws01 ansible_host=192.168.56.30 dns_domain=dc01
 ; ------------------------------------------------
 ; north.sevenkingdoms.local
 ; ------------------------------------------------
-dc02 ansible_host=192.168.56.11 dns_domain=dc01 dict_key=dc02
-srv02 ansible_host=192.168.56.22 dns_domain=dc02 dict_key=srv02
+dc02 ansible_host=192.168.56.11 dns_domain=dc01
+srv02 ansible_host=192.168.56.22 dns_domain=dc02
 ; ------------------------------------------------
 ; essos.local
 ; ------------------------------------------------
-dc03 ansible_host=192.168.56.12 dns_domain=dc03 dict_key=dc03
-srv03 ansible_host=192.168.56.23 dns_domain=dc03 dict_key=srv03
+dc03 ansible_host=192.168.56.12 dns_domain=dc03
+srv03 ansible_host=192.168.56.23 dns_domain=dc03
 ; ------------------------------------------------
 ; Other
 ; ------------------------------------------------

--- a/ad/MINILAB/providers/virtualbox/inventory
+++ b/ad/MINILAB/providers/virtualbox/inventory
@@ -1,8 +1,8 @@
 [default]
 ; Note: ansible_host *MUST* be an IPv4 address or setting things like DNS
 ; servers will break.
-dc01 ansible_host=192.168.56.30 dns_domain=dc01 dict_key=dc01
-ws01 ansible_host=192.168.56.31 dns_domain=dc01 dict_key=ws01
+dc01 ansible_host=192.168.56.30 dns_domain=dc01
+ws01 ansible_host=192.168.56.31 dns_domain=dc01
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/MINILAB/providers/vmware/inventory
+++ b/ad/MINILAB/providers/vmware/inventory
@@ -1,8 +1,8 @@
 [default]
 ; Note: ansible_host *MUST* be an IPv4 address or setting things like DNS
 ; servers will break.
-dc01 ansible_host=192.168.56.30 dns_domain=dc01 dict_key=dc01
-ws01 ansible_host=192.168.56.31 dns_domain=dc01 dict_key=ws01
+dc01 ansible_host=192.168.56.30 dns_domain=dc01
+ws01 ansible_host=192.168.56.31 dns_domain=dc01
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/NHA/providers/azure/inventory
+++ b/ad/NHA/providers/azure/inventory
@@ -1,9 +1,9 @@
 [default]
-dc01 ansible_host=192.168.58.10 dns_domain=dc01 dict_key=dc01 ansible_user=ansible ansible_password=8dCT-6546541qsdDJjgScp
-dc02 ansible_host=192.168.58.20 dns_domain=dc02 dict_key=dc02 ansible_user=ansible ansible_password=Ufe-qsdaz789bVXSx9rk
-srv01 ansible_host=192.168.58.21 dns_domain=dc02 dict_key=srv01 ansible_user=ansible ansible_password=EaqsdP+xh7sdfzaRk6j90
-srv02 ansible_host=192.168.58.22 dns_domain=dc02 dict_key=srv02 ansible_user=ansible ansible_password=978i2pF43UqsdqsdJ-qsd
-srv03 ansible_host=192.168.58.23 dns_domain=dc02 dict_key=srv03 ansible_user=ansible ansible_password=EalwxkfhqsdP+xh7sdfzaRk6j90
+dc01 ansible_host=192.168.58.10 dns_domain=dc01 ansible_user=ansible ansible_password=8dCT-6546541qsdDJjgScp
+dc02 ansible_host=192.168.58.20 dns_domain=dc02 ansible_user=ansible ansible_password=Ufe-qsdaz789bVXSx9rk
+srv01 ansible_host=192.168.58.21 dns_domain=dc02 ansible_user=ansible ansible_password=EaqsdP+xh7sdfzaRk6j90
+srv02 ansible_host=192.168.58.22 dns_domain=dc02 ansible_user=ansible ansible_password=978i2pF43UqsdqsdJ-qsd
+srv03 ansible_host=192.168.58.23 dns_domain=dc02 ansible_user=ansible ansible_password=EalwxkfhqsdP+xh7sdfzaRk6j90
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/NHA/providers/proxmox/inventory
+++ b/ad/NHA/providers/proxmox/inventory
@@ -2,11 +2,11 @@
 ; Note: ansible_host *MUST* be an IPv4 address or setting things like DNS
 ; servers will break.
 ; PROXMOX
-dc01 ansible_host=192.168.20.10 dns_domain=dc01 dict_key=dc01
-dc02 ansible_host=192.168.20.11 dns_domain=dc02 dict_key=dc02
-srv01 ansible_host=192.168.20.21 dns_domain=dc02 dict_key=srv01
-srv02 ansible_host=192.168.20.22 dns_domain=dc02 dict_key=srv02
-srv03 ansible_host=192.168.20.23 dns_domain=dc02 dict_key=srv03
+dc01 ansible_host=192.168.20.10 dns_domain=dc01
+dc02 ansible_host=192.168.20.11 dns_domain=dc02
+srv01 ansible_host=192.168.20.21 dns_domain=dc02
+srv02 ansible_host=192.168.20.22 dns_domain=dc02
+srv03 ansible_host=192.168.20.23 dns_domain=dc02
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/NHA/providers/proxmox/inventory_disablevagrant
+++ b/ad/NHA/providers/proxmox/inventory_disablevagrant
@@ -2,11 +2,11 @@
 ; Note: ansible_host *MUST* be an IPv4 address or setting things like DNS
 ; servers will break.
 ; PROXMOX
-dc01 ansible_host=192.168.20.10 dns_domain=dc01 dict_key=dc01 ansible_user=administrator ansible_password=8dCT-6546541qsdDJjgScp
-dc02 ansible_host=192.168.20.11 dns_domain=dc02 dict_key=dc02 ansible_user=administrator ansible_password=Ufe-qsdaz789bVXSx9rk
-srv01 ansible_host=192.168.20.21 dns_domain=dc02 dict_key=srv01 ansible_user=administrator ansible_password=EaqsdP+xh7sdfzaRk6j90
-srv02 ansible_host=192.168.20.22 dns_domain=dc02 dict_key=srv02 ansible_user=administrator ansible_password=978i2pF43UqsdqsdJ-qsd
-srv03 ansible_host=192.168.20.23 dns_domain=dc02 dict_key=srv03 ansible_user=administrator ansible_password=EalwxkfhqsdP+xh7sdfzaRk6j90
+dc01 ansible_host=192.168.20.10 dns_domain=dc01 ansible_user=administrator ansible_password=8dCT-6546541qsdDJjgScp
+dc02 ansible_host=192.168.20.11 dns_domain=dc02 ansible_user=administrator ansible_password=Ufe-qsdaz789bVXSx9rk
+srv01 ansible_host=192.168.20.21 dns_domain=dc02 ansible_user=administrator ansible_password=EaqsdP+xh7sdfzaRk6j90
+srv02 ansible_host=192.168.20.22 dns_domain=dc02 ansible_user=administrator ansible_password=978i2pF43UqsdqsdJ-qsd
+srv03 ansible_host=192.168.20.23 dns_domain=dc02 ansible_user=administrator ansible_password=EalwxkfhqsdP+xh7sdfzaRk6j90
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/NHA/providers/virtualbox/inventory
+++ b/ad/NHA/providers/virtualbox/inventory
@@ -2,11 +2,11 @@
 ; Note: ansible_host *MUST* be an IPv4 address or setting things like DNS
 ; servers will break.
 ; VIRTUALBOX
-dc01 ansible_host=192.168.58.10 dns_domain=dc01 dict_key=dc01
-dc02 ansible_host=192.168.58.20 dns_domain=dc02 dict_key=dc02
-srv01 ansible_host=192.168.58.21 dns_domain=dc02 dict_key=srv01
-srv02 ansible_host=192.168.58.22 dns_domain=dc02 dict_key=srv02
-srv03 ansible_host=192.168.58.23 dns_domain=dc02 dict_key=srv03
+dc01 ansible_host=192.168.58.10 dns_domain=dc01
+dc02 ansible_host=192.168.58.20 dns_domain=dc02
+srv01 ansible_host=192.168.58.21 dns_domain=dc02
+srv02 ansible_host=192.168.58.22 dns_domain=dc02
+srv03 ansible_host=192.168.58.23 dns_domain=dc02
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/NHA/providers/virtualbox/inventory_disablevagrant
+++ b/ad/NHA/providers/virtualbox/inventory_disablevagrant
@@ -2,11 +2,11 @@
 ; Note: ansible_host *MUST* be an IPv4 address or setting things like DNS
 ; servers will break.
 ; VIRTUALBOX
-dc01 ansible_host=192.168.58.10 dns_domain=dc01 dict_key=dc01 ansible_user=administrator ansible_password=8dCT-6546541qsdDJjgScp
-dc02 ansible_host=192.168.58.20 dns_domain=dc02 dict_key=dc02 ansible_user=administrator ansible_password=Ufe-qsdaz789bVXSx9rk
-srv01 ansible_host=192.168.58.21 dns_domain=dc02 dict_key=srv01 ansible_user=administrator ansible_password=EaqsdP+xh7sdfzaRk6j90
-srv02 ansible_host=192.168.58.22 dns_domain=dc02 dict_key=srv02 ansible_user=administrator ansible_password=978i2pF43UqsdqsdJ-qsd
-srv03 ansible_host=192.168.58.23 dns_domain=dc02 dict_key=srv03 ansible_user=administrator ansible_password=EalwxkfhqsdP+xh7sdfzaRk6j90
+dc01 ansible_host=192.168.58.10 dns_domain=dc01 ansible_user=administrator ansible_password=8dCT-6546541qsdDJjgScp
+dc02 ansible_host=192.168.58.20 dns_domain=dc02 ansible_user=administrator ansible_password=Ufe-qsdaz789bVXSx9rk
+srv01 ansible_host=192.168.58.21 dns_domain=dc02 ansible_user=administrator ansible_password=EaqsdP+xh7sdfzaRk6j90
+srv02 ansible_host=192.168.58.22 dns_domain=dc02 ansible_user=administrator ansible_password=978i2pF43UqsdqsdJ-qsd
+srv03 ansible_host=192.168.58.23 dns_domain=dc02 ansible_user=administrator ansible_password=EalwxkfhqsdP+xh7sdfzaRk6j90
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/NHA/providers/vmware/inventory
+++ b/ad/NHA/providers/vmware/inventory
@@ -2,11 +2,11 @@
 ; Note: ansible_host *MUST* be an IPv4 address or setting things like DNS
 ; servers will break.
 ; VIRTUALBOX
-dc01 ansible_host=192.168.58.10 dns_domain=dc01 dict_key=dc01
-dc02 ansible_host=192.168.58.20 dns_domain=dc02 dict_key=dc02
-srv01 ansible_host=192.168.58.21 dns_domain=dc02 dict_key=srv01
-srv02 ansible_host=192.168.58.22 dns_domain=dc02 dict_key=srv02
-srv03 ansible_host=192.168.58.23 dns_domain=dc02 dict_key=srv03
+dc01 ansible_host=192.168.58.10 dns_domain=dc01
+dc02 ansible_host=192.168.58.20 dns_domain=dc02
+srv01 ansible_host=192.168.58.21 dns_domain=dc02
+srv02 ansible_host=192.168.58.22 dns_domain=dc02
+srv03 ansible_host=192.168.58.23 dns_domain=dc02
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/NHA/providers/vmware/inventory_disablevagrant
+++ b/ad/NHA/providers/vmware/inventory_disablevagrant
@@ -2,11 +2,11 @@
 ; Note: ansible_host *MUST* be an IPv4 address or setting things like DNS
 ; servers will break.
 ; VIRTUALBOX
-dc01 ansible_host=192.168.58.10 dns_domain=dc01 dict_key=dc01 ansible_user=administrator ansible_password=8dCT-6546541qsdDJjgScp
-dc02 ansible_host=192.168.58.20 dns_domain=dc02 dict_key=dc02 ansible_user=administrator ansible_password=Ufe-qsdaz789bVXSx9rk
-srv01 ansible_host=192.168.58.21 dns_domain=dc02 dict_key=srv01 ansible_user=administrator ansible_password=EaqsdP+xh7sdfzaRk6j90
-srv02 ansible_host=192.168.58.22 dns_domain=dc02 dict_key=srv02 ansible_user=administrator ansible_password=978i2pF43UqsdqsdJ-qsd
-srv03 ansible_host=192.168.58.23 dns_domain=dc02 dict_key=srv03 ansible_user=administrator ansible_password=EalwxkfhqsdP+xh7sdfzaRk6j90
+dc01 ansible_host=192.168.58.10 dns_domain=dc01 ansible_user=administrator ansible_password=8dCT-6546541qsdDJjgScp
+dc02 ansible_host=192.168.58.20 dns_domain=dc02 ansible_user=administrator ansible_password=Ufe-qsdaz789bVXSx9rk
+srv01 ansible_host=192.168.58.21 dns_domain=dc02 ansible_user=administrator ansible_password=EaqsdP+xh7sdfzaRk6j90
+srv02 ansible_host=192.168.58.22 dns_domain=dc02 ansible_user=administrator ansible_password=978i2pF43UqsdqsdJ-qsd
+srv03 ansible_host=192.168.58.23 dns_domain=dc02 ansible_user=administrator ansible_password=EalwxkfhqsdP+xh7sdfzaRk6j90
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/SCCM/providers/proxmox/inventory
+++ b/ad/SCCM/providers/proxmox/inventory
@@ -4,10 +4,10 @@
 ; ------------------------------------------------
 ; sccm.lab
 ; ------------------------------------------------
-dc01 ansible_host=192.168.10.40 dns_domain=dc01 dict_key=dc01
-srv01 ansible_host=192.168.10.41 dns_domain=dc01 dict_key=srv01
-srv02 ansible_host=192.168.10.42 dns_domain=dc01 dict_key=srv02
-ws01 ansible_host=192.168.10.43 dns_domain=dc01 dict_key=ws01
+dc01 ansible_host=192.168.10.40 dns_domain=dc01
+srv01 ansible_host=192.168.10.41 dns_domain=dc01
+srv02 ansible_host=192.168.10.42 dns_domain=dc01
+ws01 ansible_host=192.168.10.43 dns_domain=dc01
 
 [all:vars]
 force_dns_server=yes

--- a/ad/SCCM/providers/virtualbox/inventory
+++ b/ad/SCCM/providers/virtualbox/inventory
@@ -4,10 +4,10 @@
 ; ------------------------------------------------
 ; sccm.lab
 ; ------------------------------------------------
-dc01 ansible_host=192.168.60.10 dns_domain=dc01 dict_key=dc01
-srv01 ansible_host=192.168.60.11 dns_domain=dc01 dict_key=srv01
-srv02 ansible_host=192.168.60.12 dns_domain=dc01 dict_key=srv02
-ws01 ansible_host=192.168.60.13 dns_domain=dc01 dict_key=ws01
+dc01 ansible_host=192.168.60.10 dns_domain=dc01
+srv01 ansible_host=192.168.60.11 dns_domain=dc01
+srv02 ansible_host=192.168.60.12 dns_domain=dc01
+ws01 ansible_host=192.168.60.13 dns_domain=dc01
 
 [all:vars]
 ; adapter created by vagrant and virtualbox

--- a/ad/SCCM/providers/vmware/inventory
+++ b/ad/SCCM/providers/vmware/inventory
@@ -4,10 +4,10 @@
 ; ------------------------------------------------
 ; sccm.lab
 ; ------------------------------------------------
-dc01 ansible_host=192.168.33.10 dns_domain=dc01 dict_key=dc01
-srv01 ansible_host=192.168.33.11 dns_domain=dc01 dict_key=srv01
-srv02 ansible_host=192.168.33.12 dns_domain=dc01 dict_key=srv02
-ws01 ansible_host=192.168.33.13 dns_domain=dc01 dict_key=ws01
+dc01 ansible_host=192.168.33.10 dns_domain=dc01
+srv01 ansible_host=192.168.33.11 dns_domain=dc01
+srv02 ansible_host=192.168.33.12 dns_domain=dc01
+ws01 ansible_host=192.168.33.13 dns_domain=dc01
 
 [all:vars]
 ; adapter created by vagrant and vmware (uncomment if you use vmware)

--- a/ad/TEMPLATE/README.md
+++ b/ad/TEMPLATE/README.md
@@ -10,8 +10,8 @@ This is the ansible inventory file.
 - This will do the mapping between IP and the configuration file (data/config.json)
 ```
 [default]
-dc01 ansible_host=192.168.56.10 dns_domain=dc01 dict_key=dc01
-srv01 ansible_host=192.168.56.11 dns_domain=dc01 dict_key=srv01
+dc01 ansible_host=192.168.56.10 dns_domain=dc01
+srv01 ansible_host=192.168.56.11 dns_domain=dc01
 ```
 
 - Vm defined in the inventory must be set into the groups to run the associated roles
@@ -107,7 +107,7 @@ srv01 ansible_host=192.168.56.11 dns_domain=dc01 dict_key=srv01
 
 ### Configuration file : hosts
 
-The host configuration contain one key by host : **the key must match the dict_key in inventory**
+The host configuration contain one key by host : **the key must match the machine in the inventory**
 
 - Example : 
 ```

--- a/ad/TEMPLATE/providers/virtualbox/inventory
+++ b/ad/TEMPLATE/providers/virtualbox/inventory
@@ -1,8 +1,8 @@
 [default]
 ; Note: ansible_host *MUST* be an IPv4 address or setting things like DNS
 ; servers will break.
-dc01 ansible_host=192.168.56.10 dns_domain=dc01 dict_key=dc01
-srv01 ansible_host=192.168.56.11 dns_domain=dc01 dict_key=srv01
+dc01 ansible_host=192.168.56.10 dns_domain=dc01
+srv01 ansible_host=192.168.56.11 dns_domain=dc01
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ad/TEMPLATE/providers/vmware/inventory
+++ b/ad/TEMPLATE/providers/vmware/inventory
@@ -1,8 +1,8 @@
 [default]
 ; Note: ansible_host *MUST* be an IPv4 address or setting things like DNS
 ; servers will break.
-dc01 ansible_host=192.168.56.10 dns_domain=dc01 dict_key=dc01
-srv01 ansible_host=192.168.56.11 dns_domain=dc01 dict_key=srv01
+dc01 ansible_host=192.168.56.10 dns_domain=dc01
+srv01 ansible_host=192.168.56.11 dns_domain=dc01
 
 [all:vars]
 ; domain_name : folder inside ad/

--- a/ansible/ad-acl.yml
+++ b/ansible/ad-acl.yml
@@ -12,7 +12,7 @@
   roles:
   - { role: 'acl', tags: 'acl'}
   vars:
-    ad_acls: "{{lab.domains[lab.hosts[dict_key].domain].acls | default({})}}"
-    domain: "{{lab.hosts[dict_key].domain}}"
+    ad_acls: "{{lab.domains[lab.hosts[inventory_hostname].domain].acls | default({})}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"

--- a/ansible/ad-child_domain.yml
+++ b/ansible/ad-child_domain.yml
@@ -14,7 +14,7 @@
     - { role: 'child_domain', tags: 'child_domain'}
     - { role: 'dns_conditional_forwarder', tags: 'dns_conditional_forwarder' }
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_password: "{{lab.domains[domain].domain_password}}"
     netbios_name: "{{lab.domains[domain].netbios_name}}"
     parent_domain: "{{'.'.join(domain.split('.')[1:])}}"
@@ -33,4 +33,4 @@
   vars:
     lab: "{{lab}}"
     domains: "{{lab.domains.keys()}}"
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"

--- a/ansible/ad-data.yml
+++ b/ansible/ad-data.yml
@@ -12,22 +12,22 @@
     - { role: 'password_policy', tags: 'policy', try_before_lock: "5", pass_length: "5", lock_duration: "00:05:00", lock_observation: "00:05:00", complexity: false}
     - { role: 'ad', tags: 'ad_domain_data' }
   vars:
-    hostname: "{{lab.hosts[dict_key].hostname}}"
-    domain: "{{lab.hosts[dict_key].domain}}"
+    hostname: "{{lab.hosts[inventory_hostname].hostname}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
-    domain_server: "{{lab.hosts[dict_key].hostname}}.{{domain}}"
-    ad_users: "{{lab.domains[lab.hosts[dict_key].domain].users}}"
-    ad_ou: "{{lab.domains[lab.hosts[dict_key].domain].organisation_units  | default({}) }}"
-    ad_groups: "{{lab.domains[lab.hosts[dict_key].domain].groups}}"
+    domain_server: "{{lab.hosts[inventory_hostname].hostname}}.{{domain}}"
+    ad_users: "{{lab.domains[lab.hosts[inventory_hostname].domain].users}}"
+    ad_ou: "{{lab.domains[lab.hosts[inventory_hostname].domain].organisation_units  | default({}) }}"
+    ad_groups: "{{lab.domains[lab.hosts[inventory_hostname].domain].groups}}"
 
 - name: "Servers AD data configuration"
   hosts: server
   roles:
     - { role: 'settings/copy_files', tags: 'download_files' }
   vars:
-    hostname: "{{lab.hosts[dict_key].hostname}}"
-    domain_ou_path: "{{lab.hosts[dict_key].path}}"
+    hostname: "{{lab.hosts[inventory_hostname].hostname}}"
+    domain_ou_path: "{{lab.hosts[inventory_hostname].path}}"
 
 - name: "Move to OU"
   hosts: dc
@@ -35,5 +35,5 @@
     - { role: 'move_to_ou', tags: 'move_to_ou'}
   vars:
     hosts_dict: "{{lab.hosts}}"
-    member_domain: "{{lab.hosts[dict_key].domain}}"
+    member_domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_password: "{{lab.domains[member_domain].domain_password}}"

--- a/ansible/ad-gmsa.yml
+++ b/ansible/ad-gmsa.yml
@@ -12,8 +12,8 @@
   roles:
   - { role: 'gmsa', tags: 'gmsa'}
   vars:
-    ad_gmsa: "{{lab.domains[lab.hosts[dict_key].domain].gmsa | default({})}}"
-    domain: "{{lab.hosts[dict_key].domain}}"
+    ad_gmsa: "{{lab.domains[lab.hosts[inventory_hostname].domain].gmsa | default({})}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
 
@@ -22,8 +22,8 @@
   roles:
   - { role: 'gmsa_hosts', tags: 'gmsa'}
   vars:
-    ad_gmsa: "{{lab.domains[lab.hosts[dict_key].domain].gmsa | default({})}}"
-    domain: "{{lab.hosts[dict_key].domain}}"
+    ad_gmsa: "{{lab.domains[lab.hosts[inventory_hostname].domain].gmsa | default({})}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
-    hostname: "{{lab.hosts[dict_key].hostname}}"
+    hostname: "{{lab.hosts[inventory_hostname].hostname}}"

--- a/ansible/ad-members.yml
+++ b/ansible/ad-members.yml
@@ -11,7 +11,7 @@
   roles:
     - { role: 'member_server', tags: 'server'}
   vars:
-    member_domain: "{{lab.hosts[dict_key].domain}}"
+    member_domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_password: "{{lab.domains[member_domain].domain_password}}"
 
 - name: "play workstations AD configuration"
@@ -19,5 +19,5 @@
   roles:
     - { role: 'commonwkstn', tags: 'workstation'}
   vars:
-    member_domain: "{{lab.hosts[dict_key].domain}}"
+    member_domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_password: "{{lab.domains[member_domain].domain_password}}"

--- a/ansible/ad-parent_domain.yml
+++ b/ansible/ad-parent_domain.yml
@@ -13,6 +13,6 @@
   roles:
   - { role: 'domain_controller', tags: 'dc_main_domains' }
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_password: "{{lab.domains[domain].domain_password}}"
     netbios_name: "{{lab.domains[domain].netbios_name}}"

--- a/ansible/ad-relations.yml
+++ b/ansible/ad-relations.yml
@@ -13,7 +13,7 @@
     - { role: "settings/adjust_rights", tags: 'adjust_rights'}
     - { role: "settings/user_rights", tags: 'adjust_rights'}
   vars:
-    local_groups: "{{lab.hosts[dict_key].local_groups  | default({}) }}"
+    local_groups: "{{lab.hosts[inventory_hostname].local_groups  | default({}) }}"
 
 
 # doesen't work see : https://github.com/ansible-collections/community.windows/blob/main/plugins/modules/win_domain_group_membership.ps1
@@ -23,8 +23,8 @@
   roles:
   - { role: 'groups_domains', tags: 'groups_domains'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
-    domain_server: "{{lab.hosts[dict_key].hostname}}.{{domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
+    domain_server: "{{lab.hosts[inventory_hostname].hostname}}.{{domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
     domain_groups_members: "{{lab.domains[domain].multi_domain_groups_member | default({}) }}"

--- a/ansible/ad-servers.yml
+++ b/ansible/ad-servers.yml
@@ -14,5 +14,5 @@
   - { role: 'settings/admin_password', tags: 'admin_password' }
   - { role: 'settings/hostname', tags: 'hostname' }
   vars:
-    local_admin_password: "{{lab.hosts[dict_key].local_admin_password}}"
-    hostname: "{{lab.hosts[dict_key].hostname}}"
+    local_admin_password: "{{lab.hosts[inventory_hostname].local_admin_password}}"
+    hostname: "{{lab.hosts[inventory_hostname].hostname}}"

--- a/ansible/ad-trusts.yml
+++ b/ansible/ad-trusts.yml
@@ -12,7 +12,7 @@
   - { role: 'settings/disable_nat_adapter' , tags: 'disable_nat_adapter'}
   - { role: 'dns_conditional_forwarder', tags: 'dns_conditional_forwarder' }
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     remote_forest: "{{lab.domains[domain].trust}}"
     zone_name: "{{remote_forest}}"
     remote_dc: "{{lab.domains[remote_forest].dc}}"
@@ -25,7 +25,7 @@
   roles:
   - { role: 'trusts', tags: 'trust' }
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
     remote_forest: "{{lab.domains[domain].trust}}"
@@ -47,7 +47,7 @@
   roles:
   - { role: 'dc_dns_conditional_forwarder', tags: 'dns_conditional_forwarder' }
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     replication: "forest"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"

--- a/ansible/adcs.yml
+++ b/ansible/adcs.yml
@@ -11,7 +11,7 @@
   roles:
   - { role: 'adcs', tags: 'adcs'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
     ca_common_name: "{{lab.domains[domain].netbios_name}}-CA"
@@ -22,7 +22,7 @@
   roles:
   - { role: 'adcs_templates', tags: 'adcs_templates'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
     ca_common_name: "{{lab.domains[domain].netbios_name}}-CA"

--- a/ansible/dhcp.yml
+++ b/ansible/dhcp.yml
@@ -8,7 +8,7 @@
   roles:
     - { role: 'dhcp', tags: 'dhcp_install'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
     sccm_server: "{{lab.domains[domain].sccm.sccm_server | default('')}}"

--- a/ansible/disable_vagrant.yml
+++ b/ansible/disable_vagrant.yml
@@ -10,7 +10,7 @@
   roles:
     - { role: 'disable_vagrant', tags: 'disable_vagrant'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
-    member_domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
+    member_domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[member_domain].domain_password}}"

--- a/ansible/enable_vagrant.yml
+++ b/ansible/enable_vagrant.yml
@@ -10,7 +10,7 @@
   roles:
     - { role: 'enable_vagrant', tags: 'disable_vagrant'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
-    member_domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
+    member_domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[member_domain].domain_password}}"

--- a/ansible/fix_trust.yml
+++ b/ansible/fix_trust.yml
@@ -23,8 +23,8 @@
           Reset-ComputerMachinePassword -Credential $Cred
         error_action: stop
         parameters:
-          domain_username: "{{lab.hosts[dict_key].domain}}\\Administrator"
-          domain_password: "{{lab.domains[lab.hosts[dict_key].domain].domain_password}}"
+          domain_username: "{{lab.hosts[inventory_hostname].domain}}\\Administrator"
+          domain_password: "{{lab.domains[lab.hosts[inventory_hostname].domain].domain_password}}"
 
     - name: "Reboot and wait for the AD system to restart"
       win_reboot:

--- a/ansible/laps.yml
+++ b/ansible/laps.yml
@@ -10,7 +10,7 @@
   roles:
     - { role: 'laps/dc', tags: 'laps-dc'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     laps_path: "{{lab.domains[domain].laps_path if lab.domains[domain].laps_path is defined else false}}"
     hosts_dict: "{{lab.hosts}}"
 
@@ -19,9 +19,9 @@
   roles:
     - { role: 'laps/server', tags: 'laps-server'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     laps_path: "{{lab.domains[domain].laps_path if lab.domains[domain].laps_path is defined else false}}"
-    use_laps: "{{lab.hosts[dict_key].use_laps if lab.hosts[dict_key].use_laps is defined else false}}"
+    use_laps: "{{lab.hosts[inventory_hostname].use_laps if lab.hosts[inventory_hostname].use_laps is defined else false}}"
 
 
 - name: verify and show laps passwords
@@ -29,7 +29,7 @@
   roles:
     - { role: 'laps/verify', tags: 'laps-verify'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     laps_path: "{{lab.domains[domain].laps_path if lab.domains[domain].laps_path is defined else false}}"
     hosts_dict: "{{lab.hosts}}"
 
@@ -38,6 +38,6 @@
   roles:
     - { role: 'laps/permissions', tags: 'laps-permissions'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     laps_path: "{{lab.domains[domain].laps_path if lab.domains[domain].laps_path is defined else false}}"
     laps_readers: "{{lab.domains[domain].laps_readers  | default([]) }}"

--- a/ansible/onlyusers.yml
+++ b/ansible/onlyusers.yml
@@ -11,11 +11,11 @@
   roles:
     - { role: 'onlyusers', tags: 'onlyusers' }
   vars:
-    hostname: "{{lab.hosts[dict_key].hostname}}"
-    domain: "{{lab.hosts[dict_key].domain}}"
+    hostname: "{{lab.hosts[inventory_hostname].hostname}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
-    domain_server: "{{lab.hosts[dict_key].hostname}}.{{domain}}"
-    ad_users: "{{lab.domains[lab.hosts[dict_key].domain].users}}"
-    ad_ou: "{{lab.domains[lab.hosts[dict_key].domain].organisation_units}}"
-    ad_groups: "{{lab.domains[lab.hosts[dict_key].domain].groups}}"
+    domain_server: "{{lab.hosts[inventory_hostname].hostname}}.{{domain}}"
+    ad_users: "{{lab.domains[lab.hosts[inventory_hostname].domain].users}}"
+    ad_ou: "{{lab.domains[lab.hosts[inventory_hostname].domain].organisation_units}}"
+    ad_groups: "{{lab.domains[lab.hosts[inventory_hostname].domain].groups}}"

--- a/ansible/roles/child_domain/tasks/main.yml
+++ b/ansible/roles/child_domain/tasks/main.yml
@@ -92,7 +92,7 @@
 #   delay: 120
 
 - name: enable the {{domain_adapter}} interface (local) for DNS client requests
-  ansible.windows.win_shell: dnscmd . /resetlistenaddresses {{ hostvars[dict_key].ansible_host }}
+  ansible.windows.win_shell: dnscmd . /resetlistenaddresses {{ hostvars[inventory_hostname].ansible_host }}
   when: two_adapters == "yes"
 
 - name: "Install XactiveDirectory"

--- a/ansible/roles/domain_controller/tasks/main.yml
+++ b/ansible/roles/domain_controller/tasks/main.yml
@@ -54,7 +54,7 @@
     state: present
 
 - name: enable only the {{domain_adapter}} interface (local) for DNS client requests
-  ansible.windows.win_shell: dnscmd . /resetlistenaddresses {{ hostvars[dict_key].ansible_host }}
+  ansible.windows.win_shell: dnscmd . /resetlistenaddresses {{ hostvars[inventory_hostname].ansible_host }}
   when: two_adapters == "yes"
 
 - name: Configure DNS Forwarders

--- a/ansible/sccm-client.yml
+++ b/ansible/sccm-client.yml
@@ -8,7 +8,7 @@
   roles:
     - { role: 'sccm/config/client_install', tags: 'sccm_client_install' }
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
     sccm_server: "{{lab.domains[domain].sccm.sccm_server | default('')}}"

--- a/ansible/sccm-config.yml
+++ b/ansible/sccm-config.yml
@@ -14,7 +14,7 @@
     - { role: 'sccm/config/client_install', tags: 'sccm_client_install'}
     - { role: 'sccm/config/users', tags: 'sccm_users'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
     sccm_server: "{{lab.domains[domain].sccm.sccm_server | default('')}}"

--- a/ansible/sccm-install.yml
+++ b/ansible/sccm-install.yml
@@ -8,7 +8,7 @@
   roles:
     - { role: 'sccm/install/prerequistes', tags: 'sccm_prerequistes', when: sccm_server != ''}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
     site_code: "{{lab.domains[domain].sccm.site_code}}"
@@ -24,7 +24,7 @@
     - { role: 'sccm/install/wsus', tags: 'sccm_wsus'}
     - { role: 'sccm/install/mecm', tags: 'sccm_mecm'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
     site_code: "{{lab.domains[domain].sccm.site_code}}"

--- a/ansible/sccm-pxe.yml
+++ b/ansible/sccm-pxe.yml
@@ -9,7 +9,7 @@
     - { role: 'sccm/config/pxe', tags: 'sccm_pxe'}
     - { role: 'sccm/pxe', tags: 'sccm_pxe' }
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_username: "{{domain}}\\Administrator"
     domain_password: "{{lab.domains[domain].domain_password}}"
     site_code: "{{lab.domains[domain].sccm.site_code}}"

--- a/ansible/security.yml
+++ b/ansible/security.yml
@@ -25,10 +25,10 @@
     - include_role:
         name: "security/{{secu}}"
       vars:
-        security_vars : "{{ lab.hosts[dict_key].security_vars[secu] | default({}) }}"
-        domain: "{{lab.hosts[dict_key].domain}}"
+        security_vars : "{{ lab.hosts[inventory_hostname].security_vars[secu] | default({}) }}"
+        domain: "{{lab.hosts[inventory_hostname].domain}}"
         domain_username: "{{domain}}\\Administrator"
         domain_password: "{{lab.domains[domain].domain_password}}"
-      loop: "{{lab.hosts[dict_key].security | default([]) }}"
+      loop: "{{lab.hosts[inventory_hostname].security | default([]) }}"
       loop_control:
         loop_var: secu

--- a/ansible/servers.yml
+++ b/ansible/servers.yml
@@ -16,19 +16,19 @@
     - { role: 'mssql', tags: 'mssql'}
     - { role: 'mssql_link', tags: 'mssql, mssql_link'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
-    SQLSVCACCOUNT_NAME: "{{lab.hosts[dict_key].mssql.svcaccount| default('NT AUTHORITY\\NETWORK SERVICE')}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
+    SQLSVCACCOUNT_NAME: "{{lab.hosts[inventory_hostname].mssql.svcaccount| default('NT AUTHORITY\\NETWORK SERVICE')}}"
     SQLSVCACCOUNT_NAMEDOMAIN: "{{domain}}\\{{SQLSVCACCOUNT_NAME}}"
     SQLSVCACCOUNT: "{{SQLSVCACCOUNT_NAME if SQLSVCACCOUNT_NAME == 'NT AUTHORITY\\NETWORK SERVICE' else SQLSVCACCOUNT_NAMEDOMAIN }}"
     SQLSVCPASSWORD: "{{lab.domains[domain].users[SQLSVCACCOUNT_NAME].password| default('')}}"
     SQLYSADMIN: "{{SQLSVCACCOUNT}}"
     domain_admin: "{{domain}}\\Administrator"
     domain_admin_password: "{{lab.domains[domain].domain_password}}"
-    sql_sysadmins: "{{lab.hosts[dict_key].mssql.sysadmins | default([]) }}"
-    executeaslogin: "{{lab.hosts[dict_key].mssql.executeaslogin  | default({}) }}"
-    executeasuser:  "{{lab.hosts[dict_key].mssql.executeasuser | default({}) }}"
-    sa_password: "{{lab.hosts[dict_key].mssql.sa_password}}"
-    linked_servers: "{{lab.hosts[dict_key].mssql.linked_servers | default({}) }}"
+    sql_sysadmins: "{{lab.hosts[inventory_hostname].mssql.sysadmins | default([]) }}"
+    executeaslogin: "{{lab.hosts[inventory_hostname].mssql.executeaslogin  | default({}) }}"
+    executeasuser:  "{{lab.hosts[inventory_hostname].mssql.executeasuser | default({}) }}"
+    sa_password: "{{lab.hosts[inventory_hostname].mssql.sa_password}}"
+    linked_servers: "{{lab.hosts[inventory_hostname].mssql.linked_servers | default({}) }}"
 
 - name: "Install SQL Server Management Studio"
   hosts: mssql_ssms
@@ -40,7 +40,7 @@
   roles:
     - { role: 'mssql_reporting', tags: 'mssql_reporting'}
   vars:
-    domain: "{{lab.hosts[dict_key].domain}}"
+    domain: "{{lab.hosts[inventory_hostname].domain}}"
     domain_admin: "{{domain}}\\Administrator"
     domain_admin_password: "{{lab.domains[domain].domain_password}}"
 

--- a/ansible/vulnerabilities.yml
+++ b/ansible/vulnerabilities.yml
@@ -11,11 +11,11 @@
     - include_role:
         name: "vulns/{{vuln}}"
       vars:
-        vulns_vars : "{{ lab.hosts[dict_key].vulns_vars[vuln] | default({}) }}"
-        domain: "{{lab.hosts[dict_key].domain}}"
+        vulns_vars : "{{ lab.hosts[inventory_hostname].vulns_vars[vuln] | default({}) }}"
+        domain: "{{lab.hosts[inventory_hostname].domain}}"
         domain_username: "{{domain}}\\Administrator"
         domain_password: "{{lab.domains[domain].domain_password}}"
-      loop: "{{lab.hosts[dict_key].vulns | default([]) }}"
+      loop: "{{lab.hosts[inventory_hostname].vulns | default([]) }}"
       loop_control:
         loop_var: vuln
 
@@ -24,4 +24,4 @@
       vars:
         script_path: "../ad/{{domain_name}}/scripts"
         ps_script: "{{script_path}}/{{item}}"
-      loop: "{{lab.hosts[dict_key].scripts | default([]) }}"
+      loop: "{{lab.hosts[inventory_hostname].scripts | default([]) }}"


### PR DESCRIPTION
`dict_key` is defined for each hosts in ansible's inventory. Its value is used to access configuration parameters in a lab's `data/config.json` file. Since the value of `dict_key` is always equal to the machine's name in ansible's inventory, it is equal to ansible's `inventory_hostname` variable.

This patch:

- replaces `dict_key` by `inventory_hostname` in playbooks and roles;
- removes `dict_key` from inventories.