### PR TITLE
Fix typo in ad/GOAD/scripts  /constrained_delegation_kerb_only.ps1

### DIFF
--- a/ad/GOAD/scripts/constrained_delegation_kerb_only.ps1
+++ b/ad/GOAD/scripts/constrained_delegation_kerb_only.ps1
@@ -1,4 +1,4 @@
 # https://www.thehacker.recipes/ad/movement/kerberos/delegations/constrained#without-protocol-transition
-Set-ADComputer -Identity "castelblack$" -ServicePrincipalNames @{Add='HTTP/winterfell.north.sevenkingdoms.local'}
-Set-ADComputer -Identity "castelblack$" -Add @{'msDS-AllowedToDelegateTo'=@('HTTP/winterfell.north.sevenkingdoms.local','HTTP/winterfell')}
-# Set-ADComputer -Identity "castelblack$" -Add @{'msDS-AllowedToDelegateTo'=@('CIFS/winterfell.north.sevenkingdoms.local','CIFS/winterfell')}
+Set-ADComputer -Identity "castleblack$" -ServicePrincipalNames @{Add='HTTP/winterfell.north.sevenkingdoms.local'}
+Set-ADComputer -Identity "castleblack$" -Add @{'msDS-AllowedToDelegateTo'=@('HTTP/winterfell.north.sevenkingdoms.local','HTTP/winterfell')}
+# Set-ADComputer -Identity "castleblack$" -Add @{'msDS-AllowedToDelegateTo'=@('CIFS/winterfell.north.sevenkingdoms.local','CIFS/winterfell')}


### PR DESCRIPTION
Ansible role failed with the following error:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NoneType: None
fatal: [dc02]: FAILED! => {"changed": true, "msg": "non-zero return code", "rc": 1, "stderr": "Cannot find an object with identity: 'castelblack$' under: 'DC=north,DC=sevenkingdoms,DC=local'.At C:\\Users\\vagrant\\AppData\\Local\\Temp\\ansible-tmp-1729774278.2965558-178710-193514916936457\\constrained_delegation_kerb_only.ps1:2 char:1+ Set-ADComputer -Identity \"castelblack$\" -ServicePrincipalNames @{Add= ...+ 
```

Fixed the typo and installation continued gracefully.