### PR TITLE
fix: 🐛 Add router to DHCP server options

### DIFF
--- a/ansible/roles/dhcp/tasks/main.yml
+++ b/ansible/roles/dhcp/tasks/main.yml
@@ -27,9 +27,18 @@
       Add-DhcpServerV4Scope -Name "DHCP Scope" -StartRange {{ip_from}} -EndRange {{ip_to}} -SubnetMask {{ip_mask}} -LeaseDuration {{lease_duration}}
     }
 
-- name: Add DNS Server, Router Gateway Options in DHCP
+- name: Get default gateway
   win_shell: |
-    Set-DhcpServerV4OptionValue -DnsServer {{dns_ip}}
+    (Get-NetRoute -DestinationPrefix "0.0.0.0/0").NextHop
+  register: ip_gateway_command
+
+- name: Set ip_gateway
+  set_fact:
+    ip_gateway: "{{ ip_gateway_command.stdout | trim }}"
+
+- name: Add DNS Server and Default Gateway Options in DHCP
+  win_shell: |
+    Set-DhcpServerV4OptionValue -DnsServer {{dns_ip}} -Router {{ip_gateway}}
 
 #- name: create server option boot server hostname (MECM)
 #  win_shell: |


### PR DESCRIPTION
This fixes an issue with Ludus deployments where users adding additional machines to GOAD will have those machines get DHCP from the DC, which does not include a default route, and thus the machines cannot be provisioned by Ludus. This change finds the default route for the DC, and adds that as the router option for the DHCP server. This should not change anything for non-Ludus GOAD deployments, as the VMs will simply get a default route with their DHCP response.