### PR TITLE
Fixed the checking of available space

### DIFF
--- a/goad/command/cmd.py
+++ b/goad/command/cmd.py
@@ -102,7 +102,7 @@ class Command:
         disk_usage = psutil.disk_usage('.')
         free_disk_gb = disk_usage.free / (1024 ** 3)  # Convert bytes to GB
         if free_disk_gb < min_disk_gb:
-            Log.warning(f'not enought disk space, only {str(free_disk_gb)} Gb available')
+            Log.warning(f'not enough disk space, only {str(free_disk_gb)} Gb available')
             return False
         return True
 

--- a/goad/command/cmd.py
+++ b/goad/command/cmd.py
@@ -98,7 +98,8 @@ class Command:
         pass
 
     def check_disk(self, min_disk_gb=120):
-        disk_usage = psutil.disk_usage('/')
+        # If the system has multiple mountpoints, '.' will correctly calculate the available space on the current disk
+        disk_usage = psutil.disk_usage('.')
         free_disk_gb = disk_usage.free / (1024 ** 3)  # Convert bytes to GB
         if free_disk_gb < min_disk_gb:
             Log.warning(f'not enought disk space, only {str(free_disk_gb)} Gb available')


### PR DESCRIPTION
Hi

I just tried to deploy GOAD on a system which has multiple disks. While `/` is mounted on a relatively small disk, `/GOAD` goes to a different disk with plenty of size. However, the `check` command was telling me that there wasn't enough space.

After adding the modification I'm submitting wiht this PR, that error went away and I proceeded with the installation. Since the labs seem to be installed under `/GOAD/workspace/`, I believe that the actual size to calculate should be `.` (the current directory), instead of `/`.

Mind you, it's the first time I'm deploying GOAD; so I might be wrong and this PR probably should be rejected.


I also took the liberty of fixing the small typo there in the error message.
