### PR TITLE
Add Azure NSG to allow only SSH inbound

### DIFF
--- a/template/provider/azure/network.tf
+++ b/template/provider/azure/network.tf
@@ -12,6 +12,29 @@ resource "azurerm_subnet" "subnet" {
   address_prefixes     = ["{{ip_range}}.0/24"]
 }
 
+resource "azurerm_network_security_group" "nsg" {
+  name                 = "{{lab_name}}-subnet-nsg"
+  location             = azurerm_resource_group.resource_group.location
+  resource_group_name  = azurerm_resource_group.resource_group.name
+
+  security_rule {
+    name                          = "AllowSSHInboundOnly"
+    priority                      = 100
+    direction                     = "Inbound"
+    access                        = "Allow"
+    protocol                      = "Tcp"
+    source_port_range             = "*"
+    destination_port_range        = "22"
+    source_address_prefix         = "*"
+    destination_address_prefix    = "*"
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "nsg_association" {
+  subnet_id                       = azurerm_subnet.subnet.id
+  network_security_group_id       = azurerm_network_security_group.nsg.id
+}
+
 resource "azurerm_network_interface" "goad-vm-nic" {
   for_each = var.vm_config
 


### PR DESCRIPTION
Hello,

This change adds a Network Security Group (NSG) to the Azure provider. This NSG restricts inbound connections from the internet to SSH only.

As an example, currently if a user were to run a `SimpleHTTPServer` or SMB server on the jumpbox to transfer files to the Windows VMs, that server would be exposed to the internet via the jumpbox's public IP.

This NSG allows users to serve files to the Windows VMs via the jumpbox without exposing their HTTP/SMB servers to the internet.