### PR TITLE
Update windows.md

### DIFF
--- a/docs/mkdocs/docs/installation/windows.md
+++ b/docs/mkdocs/docs/installation/windows.md
@@ -19,7 +19,7 @@
 
     - Virtualbox
 
-        - Install virtualbox <= 7.0 (vagrant support only to vbox7.0 at the time of writing) : [https://www.virtualbox.org/wiki/Download_Old_Builds_7_0](https://www.virtualbox.org/wiki/Download_Old_Builds_7_0)
+        - Install virtualbox <= 7.1.x (vagrant supports up to vbox7.1.x at the time of writing) : [https://www.virtualbox.org/wiki/Downloads](https://www.virtualbox.org/wiki/Downloads)
 
         - Install the following vagrant plugins:
 


### PR DESCRIPTION
The VirtualBox provider is compatible with VirtualBox versions 4.0.x, 4.1.x, 4.2.x, 4.3.x, 5.0.x, 5.1.x, 5.2.x, 6.0.x, 6.1.x, 7.0.x, and 7.1.x. https://developer.hashicorp.com/vagrant/docs/providers/virtualbox

VirtualBox headless will not work with versions < 7.1.x. on Windows 11.