### PR TITLE
Add PROVISIONING box_version to fix deployment issue with Vagrant

### DIFF
--- a/template/provider/vmware/Vagrantfile
+++ b/template/provider/vmware/Vagrantfile
@@ -11,6 +11,7 @@ boxes.append(
     { :name => "PROVISIONING",
       :ip => "{{ip_range}}.3",
       :box => "bento/ubuntu-22.04",
+      :box_version => "202401.31.0",
       :os => "linux",
       :cpus => 2,
       :mem => 2000,

--- a/template/provider/vmware_esxi/Vagrantfile
+++ b/template/provider/vmware_esxi/Vagrantfile
@@ -16,6 +16,7 @@ boxes.append(
     { :name => "PROVISIONING",
       :ip => "{{ip_range}}.3",
       :box => "bento/ubuntu-22.04",
+      :box_version => "202401.31.0",
       :os => "linux",
       :cpus => 2,
       :mem => 2000,


### PR DESCRIPTION
A new image for bento/ubuntu-22.04 was released on February 21 that broke Vagrant deployment, as it appears as though it does not have the base Vagrant insecure key. As the insecure key is not found, a new key is not generated, and thus deployments will just get stuck at "PROVISIONING: Warning: Authentication failure. Retrying...".

Adding in the last known good box_version for ubuntu-22.04 will fix the issue.

Related issue:
- https://github.com/Orange-Cyberdefense/GOAD/issues/376