### PR TITLE
Update WS01 extension to use win10-22h2-x64-enterprise-template (#423)

### DIFF
--- a/extensions/ws01/providers/ludus/config.yml
+++ b/extensions/ws01/providers/ludus/config.yml
@@ -1,6 +1,6 @@
   - vm_name: "{{ range_id }}-GOAD-WS01"
     hostname: "{{ range_id }}-WS01"
-    template: win10-21h2-x64-enterprise-template
+    template: win10-22h2-x64-enterprise-template
     vlan: 10
     ip_last_octet: 31
     ram_gb: 4


### PR DESCRIPTION
Fix for WS01 using an old image win10-21h2-x64-enterprise-template, and changed with win10-22h2-x64-enterprise-template