### PR TITLE
Return error code if goad.sh process fails

### DIFF
--- a/goad.py
+++ b/goad.py
@@ -360,6 +360,7 @@ class Goad(cmd.Cmd):
                     self.refresh_prompt()
                 else:
                     Log.error('Providing error stop')
+                    sys.exit(1)
 
     def do_install_instance(self, arg=''):
         Log.info('Launch providing')
@@ -376,6 +377,7 @@ class Goad(cmd.Cmd):
             self.refresh_prompt()
         else:
             Log.error('Providing error stop')
+            sys.exit(1)
 
     def do_create_empty(self, arg=''):
         Log.info('Create instance folder')

--- a/goad.sh
+++ b/goad.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 py=python3
 venv="$HOME/.goad/.venv"
@@ -24,7 +25,7 @@ then
       fi
   else
       echo "Python version is < 3.8 please update python before install"
-      exit
+      exit 1
   fi
 
   if [ "$($py -m venv -h 2>/dev/null | grep -i 'usage:')" ]; then
@@ -33,7 +34,7 @@ then
     echo "venv module is not installed."
     echo "please install $py-venv according to your system"
     echo "exit"
-    exit 0
+    exit 1
   fi
 
   echo '[+] venv not found, start python venv creation'
@@ -50,7 +51,7 @@ then
   else
     echo "Error in venv creation"
     rm -rf $venv
-    exit 0
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
I want to run GOAD deployment on a pipeline, but errors get swallowed so the pipeline cannot tell if it failed. This change just provides an error state if goad.sh or goad.py fails.