### PR TITLE
Fix extensions not running on jumpbox due to missing sshpass package

### DIFF
--- a/scripts/setup_local_jumpbox.sh
+++ b/scripts/setup_local_jumpbox.sh
@@ -2,7 +2,7 @@
 
 # Install git and python3
 sudo apt-get update
-sudo apt-get install -y git python3-venv python3-pip git
+sudo apt-get install -y git python3-venv python3-pip git sshpass
 
 # git clone goad
 GOAD_REPO=/home/vagrant/GOAD


### PR DESCRIPTION
The `sshpass` package is missing from the local jumpbox, meaning some extensions that depend on it (like `wazuh`) will likely fail. This fix ensures `sshpass` is installed on the jumpbox.