### PR TITLE
linux: ensure openssh-server is installed

### DIFF
--- a/ansible/roles/linux/add_linux_to_domain/tasks/main.yml
+++ b/ansible/roles/linux/add_linux_to_domain/tasks/main.yml
@@ -9,6 +9,8 @@
       - realmd
       - adcli
       - packagekit
+      # ensure openssh service is available
+      - openssh-server
     state: present
 
 - name: Create KRB5 File


### PR DESCRIPTION
Ensures that sshd is installed on Linux systems before attempting to configure sshd.