### PR TITLE
Fix/vmware windows

### DIFF
--- a/docs/mkdocs/docs/troobleshoot.md
+++ b/docs/mkdocs/docs/troobleshoot.md
@@ -340,4 +340,45 @@ fatal: [dc01]: UNREACHABLE! => {"changed": false, "msg": "ssl: HTTPSConnectionPo
 - may be the vm is not well ready after the terraform creation. retry the install.
 - if you still get the error connect to the vm and verify the static ip is corresponding with the one expect.
 
+## Windows + VMware : SSH/SCP connection to VMs times out
+```
+ssh: connect to host 192.168.56.X port 22: Connection timed out
+```
+
+or vagrant prints during `vagrant up` :
+
+```
+==> GOAD-DC01: Configuring secondary network adapters through VMware
+==> GOAD-DC01: on Windows is not yet supported. You will need to manually
+==> GOAD-DC01: configure the network adapter.
+```
+
+Vagrant cannot auto-configure VMware private network adapters on Windows. The VMs never get their `192.168.56.x` IPs.
+
+- solution : configure VMware Virtual Network Editor manually
+    - Open Virtual Network Editor as Administrator
+    - Create or edit a host-only network (e.g. `VMnet2`) :
+        - Subnet IP : `192.168.56.0`
+        - Subnet Mask : `255.255.255.0`
+        - DHCP : unchecked
+        - Connect a host virtual adapter : checked
+    - Open `ncpa.cpl` and verify VMware Network Adapter VMnet2 has IP `192.168.56.1`. If not, set it manually (IPv4 -> static -> `192.168.56.1`, mask `255.255.255.0`)
+
+## Windows + VMware : Port 2210 collision with PROVISIONING VM
+
+```
+Vagrant cannot forward the specified ports on this VM, since they
+would collide with some other application that is already listening
+on these ports. The forwarded port to 2210 is already in use
+on the host machine.
+```
+
+When using the `vm` provisioning method with the full GOAD lab (5 Windows VMs), Vagrant auto-corrects their forwarded ports into the 2200+ range which collides with the PROVISIONING VM SSH port (2210).
+
+- solution : edit `template/provider/vmware/Vagrantfile` and change the provisioning VM forwarded port to a value outside the auto-correction range
+
+```
+# change :host => 2210 to :host => 2250
+:forwarded_port => [ {:guest => 22, :host => 2250, :id => "ssh"} ]
+```
 

--- a/goad/command/windows.py
+++ b/goad/command/windows.py
@@ -17,14 +17,16 @@ class WindowsCommand(Command):
             Log.success(f'File {file} present in the file system')
         return exist
 
-    def is_in_path(self, bin_file):
+    def is_in_path(self, bin_file, show_log=True):
         command = f'where {bin_file} >nul'
         try:
             subprocess.run(command, shell=True, check=True)
-            Log.success(f'{bin_file} found in PATH')
+            if show_log:
+                Log.success(f'{bin_file} found in PATH')
             return True
         except subprocess.CalledProcessError as e:
-            Log.error(f'{bin_file} not found in PATH')
+            if show_log:
+                Log.error(f'{bin_file} not found in PATH')
             return False
 
     # CHECK

--- a/template/provider/virtualbox/Vagrantfile
+++ b/template/provider/virtualbox/Vagrantfile
@@ -75,7 +75,7 @@ boxes.append(
 
       if box.has_key?(:forwarded_port)
         # forwarded port explicit
-        box[:forwarded_port] do |forwarded_port|
+        box[:forwarded_port].each do |forwarded_port|
           target.vm.network :forwarded_port, guest: forwarded_port[:guest], host: forwarded_port[:host], host_ip: "127.0.0.1", id: forwarded_port[:id]
         end
       end

--- a/template/provider/vmware/Vagrantfile
+++ b/template/provider/vmware/Vagrantfile
@@ -76,7 +76,7 @@ boxes.append(
 
       if box.has_key?(:forwarded_port)
         # forwarded port explicit
-        box[:forwarded_port] do |forwarded_port|
+        box[:forwarded_port].each do |forwarded_port|
           target.vm.network :forwarded_port, guest: forwarded_port[:guest], host: forwarded_port[:host], host_ip: "127.0.0.1", id: forwarded_port[:id]
         end
       end

--- a/template/provider/vmware/Vagrantfile
+++ b/template/provider/vmware/Vagrantfile
@@ -37,6 +37,7 @@ boxes.append(
   config.vm.graceful_halt_timeout = 600
   config.winrm.retry_limit = 30
   config.winrm.retry_delay = 10
+  config.winrm.ssl_peer_verification = false
 
   boxes.each do |box|
     config.vm.define box[:name] do |target|

--- a/template/provider/vmware_esxi/Vagrantfile
+++ b/template/provider/vmware_esxi/Vagrantfile
@@ -82,7 +82,7 @@ boxes.append(
 
       if box.has_key?(:forwarded_port)
         # forwarded port explicit
-        box[:forwarded_port] do |forwarded_port|
+        box[:forwarded_port].each do |forwarded_port|
           target.vm.network :forwarded_port, guest: forwarded_port[:guest], host: forwarded_port[:host], host_ip: "127.0.0.1", id: forwarded_port[:id]
         end
       end

--- a/template/provider/vmware_esxi/Vagrantfile
+++ b/template/provider/vmware_esxi/Vagrantfile
@@ -37,6 +37,7 @@ boxes.append(
   config.vm.graceful_halt_timeout = 600
   config.winrm.retry_limit = 30
   config.winrm.retry_delay = 10
+  config.winrm.ssl_peer_verification = false
 
   boxes.each do |box|
     config.vm.define box[:name] do |target|


### PR DESCRIPTION
## Fixes

### `WindowsCommand.is_in_path()` signature mismatch

Base class accepts `show_log` param, but the Windows override didn't. Crashes on Windows when `on_ludus()` calls `self.is_in_path('ludus', False)`.

### WinRM SSL verification failure (VMware)

Windows VMs use self-signed certs. Added `config.winrm.ssl_peer_verification = false` to `vmware` and `vmware_esxi` Vagrantfiles.

### Broken `forwarded_port` iteration (all providers)

```ruby
# Before (silently does nothing):
box[:forwarded_port] do |forwarded_port|
# After:
box[:forwarded_port].each do |forwarded_port|
```

Port forwarding (e.g. provisioning VM SSH `22 -> 2210`) was never configured. Fixed in `vmware`, `vmware_esxi`, and `virtualbox` Vagrantfiles.

### VMware troubleshooting docs

Added section to `troobleshoot.md` for port conflicts and VMnet adapter setup on Windows.

TL;DR: it works for me, unsure if this is generic Windows vmware issues or just me. Had the same issue across 2 different builds on Windows vmware. 