### PR TITLE
Added check, snapshot and reset, updated docs

### DIFF
--- a/docs/mkdocs/docs/usage/goad_args.md
+++ b/docs/mkdocs/docs/usage/goad_args.md
@@ -3,28 +3,30 @@
 - Launch goad.py script (or goad.sh wrapper) with arguments
 
 ```bash
-usage: goad.py [-h] [-t TASK] [-l LAB] [-p PROVIDER] [-ip IP_RANGE] [-m METHOD] [-i INSTANCE] [-e EXTENSIONS] [-a ANSIBLE_ONLY] [-r RUN_PLAYBOOK]
+usage: goad.py [-h] [-t {install,check,start,stop,restart,destroy,status,snapshot,reset,show}] [-l LAB] [-p PROVIDER] [-ip IP_RANGE] [-m METHOD]
+               [-i INSTANCE] [-e EXTENSIONS] [-a ANSIBLE_ONLY] [-r RUN_PLAYBOOK] [-d DISABLE_DEPENDENCIES]
 
 Description : goad lab management console.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  -t TASK, --task TASK  tasks available : (install/start/stop/restart/destroy/status/show)
-  -l LAB, --lab LAB     lab to use (default: GOAD)
-  -p PROVIDER, --provider PROVIDER
+  -t, --task {install,check,start,stop,restart,destroy,status,snapshot,reset,show}
+  -l, --lab LAB         lab to use (default: GOAD)
+  -p, --provider PROVIDER
                         provider to use (default: vmware)
-  -ip IP_RANGE, --ip_range IP_RANGE
+  -ip, --ip_range IP_RANGE
                         ip range to use (default: 192.168.56)
-  -m METHOD, --method METHOD
-                        deploy method to use (default: local)
-  -i INSTANCE, --instance INSTANCE
+  -m, --method METHOD   deploy method to use (default: local)
+  -i, --instance INSTANCE
                         use a specific instance (use default if not selected)
-  -e EXTENSIONS, --extensions EXTENSIONS
+  -e, --extensions EXTENSIONS
                         extensions to use
-  -a ANSIBLE_ONLY, --ansible_only ANSIBLE_ONLY
+  -a, --ansible_only ANSIBLE_ONLY
                         run only provisioning (ansible) on instance (-i) (for task install only)
-  -r RUN_PLAYBOOK, --run_playbook RUN_PLAYBOOK
+  -r, --run_playbook RUN_PLAYBOOK
                         run only one ansible playbook on instance (-i) (for task install only)
+  -d, --disable_dependencies DISABLE_DEPENDENCIES
+                        disable_dependencies
 
 Example :
  - Install GOAD on virtualbox : python3 goad.py -t install -l GOAD -p virtualbox

--- a/goad.py
+++ b/goad.py
@@ -454,11 +454,11 @@ class Goad(cmd.Cmd):
 
 
 def parse_args():
-    task_help = 'tasks available : (install/start/stop/restart/destroy/status/show)'
+    allowed_tasks = ["install", "check", "start", "stop", "restart", "destroy", "status", "snapshot", "reset", "show"]
     parser = argparse.ArgumentParser(prog='goad.py',
                                      description='Description : goad lab management console.',
                                      epilog=show_help(), formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("-t", "--task", help=f"{task_help}", required=False)
+    parser.add_argument("-t", "--task", choices=allowed_tasks, required=False)
     parser.add_argument("-l", "--lab", help="lab to use (default: GOAD)", default='GOAD', required=False)
     parser.add_argument("-p", "--provider", help="provider to use (default: vmware)", default='vmware', required=False)
     parser.add_argument("-ip", "--ip_range", help="ip range to use (default: 192.168.56)", default='', required=False)


### PR DESCRIPTION
Hey, this PR updates some inconsistencies of the help-text that I have noticed.

The `check`, `snapshot`, `reset` were missing from the helptext.
Since there was no error-checking, I used the `choices`-keyword for the argument.
This way, argparse not only adds the available options itself, but also does some error-checking and prints an error.

I also updated the documentation-page that covers the helptext.