### PR TITLE
fix SSMS 18 install (old link points to 22)

### DIFF
--- a/ansible/roles/mssql_ssms/tasks/main.yml
+++ b/ansible/roles/mssql_ssms/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: get the installer
   win_get_url:
-      url: 'https://aka.ms/ssmsfullsetup'
+      url: 'https://go.microsoft.com/fwlink/?linkid=2199013&clcid=0x409'
       dest: 'c:\setup\mssql\SSMS_installer.exe'
   when: not ssms_installer_file.stat.exists
 


### PR DESCRIPTION
the download link for SSMS points to version 22. changed the download link to version 18 as plublished on this page: https://learn.microsoft.com/en-us/ssms/release-history